### PR TITLE
feat: 사용자(User) 도메인 구조 세팅 및 엔티티 정의

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/DeokhugamApplication.java
+++ b/src/main/java/com/codeit/team4/deokhugam/DeokhugamApplication.java
@@ -2,7 +2,6 @@ package com.codeit.team4.deokhugam;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 public class DeokhugamApplication {

--- a/src/main/java/com/codeit/team4/deokhugam/DeokhugamApplication.java
+++ b/src/main/java/com/codeit/team4/deokhugam/DeokhugamApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class DeokhugamApplication {
 

--- a/src/main/java/com/codeit/team4/deokhugam/DeokhugamApplication.java
+++ b/src/main/java/com/codeit/team4/deokhugam/DeokhugamApplication.java
@@ -2,7 +2,9 @@ package com.codeit.team4.deokhugam;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class DeokhugamApplication {
 

--- a/src/main/java/com/codeit/team4/deokhugam/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package com.codeit.team4.deokhugam.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+
+}

--- a/src/main/java/com/codeit/team4/deokhugam/global/entity/BaseEntity.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/entity/BaseEntity.java
@@ -1,0 +1,28 @@
+package com.codeit.team4.deokhugam.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "id", nullable = false, updatable = false)
+    private UUID id;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    protected Instant createdAt;
+}

--- a/src/main/java/com/codeit/team4/deokhugam/global/entity/BaseEntity.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/entity/BaseEntity.java
@@ -24,5 +24,5 @@ public abstract class BaseEntity {
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
-    protected Instant createdAt;
+    private Instant createdAt;
 }

--- a/src/main/java/com/codeit/team4/deokhugam/global/entity/BaseUpdatableEntity.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/entity/BaseUpdatableEntity.java
@@ -1,0 +1,16 @@
+package com.codeit.team4.deokhugam.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import java.time.Instant;
+import lombok.Getter;
+import org.springframework.data.annotation.LastModifiedDate;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseUpdatableEntity extends BaseEntity {
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    protected Instant updatedAt;
+}

--- a/src/main/java/com/codeit/team4/deokhugam/global/entity/BaseUpdatableEntity.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/entity/BaseUpdatableEntity.java
@@ -12,5 +12,5 @@ public abstract class BaseUpdatableEntity extends BaseEntity {
 
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
-    protected Instant updatedAt;
+    private Instant updatedAt;
 }

--- a/src/main/java/com/codeit/team4/deokhugam/user/entity/User.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/entity/User.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -60,5 +61,30 @@ public class User {
 
     public boolean isDeleted() {
         return this.deletedAt != null;
+    }
+
+    public void softDelete() {
+        if (this.deletedAt != null) {
+            return;
+        }
+        Instant now = Instant.now();
+        this.deletedAt = now;
+        this.updatedAt = now;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof User other)) {
+            return false;
+        }
+        return id != null && id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/user/entity/User.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/entity/User.java
@@ -1,15 +1,12 @@
 package com.codeit.team4.deokhugam.user.entity;
 
+import com.codeit.team4.deokhugam.global.entity.BaseUpdatableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.Objects;
-import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,11 +19,7 @@ import lombok.NoArgsConstructor;
         }
 )
 @NoArgsConstructor
-public class User {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+public class User extends BaseUpdatableEntity {
 
     @Column(nullable = false, length = 100)
     private String email;
@@ -37,12 +30,6 @@ public class User {
     @Column(nullable = false)
     private String password;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private Instant createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private Instant updatedAt;
-
     @Column(name = "deleted_at")
     private Instant deletedAt;
 
@@ -50,41 +37,21 @@ public class User {
         this.email = email;
         this.nickname = nickname;
         this.password = password;
-        this.createdAt = Instant.now();
-        this.updatedAt = Instant.now();
-    }
-
-    public void updateNickname(String nickname) {
-        this.nickname = nickname;
-        this.updatedAt = Instant.now();
     }
 
     public boolean isDeleted() {
         return this.deletedAt != null;
     }
 
-    public void softDelete() {
-        if (this.deletedAt != null) {
-            return;
-        }
-        Instant now = Instant.now();
-        this.deletedAt = now;
-        this.updatedAt = now;
-    }
-
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof User other)) {
-            return false;
-        }
-        return id != null && id.equals(other.id);
+        if (this == o) return true;
+        if (!(o instanceof User other)) return false;
+        return getId() != null && getId().equals(other.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(id);
+        return Objects.hashCode(getId());
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/user/entity/User.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/entity/User.java
@@ -1,0 +1,64 @@
+package com.codeit.team4.deokhugam.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(
+        name = "users",
+        indexes = {
+                @Index(name = "idx_users_deleted_at", columnList = "deleted_at")
+        }
+)
+@NoArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
+    @Column(nullable = false, length = 50)
+    private String nickname;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
+    public User(String email, String nickname, String password) {
+        this.email = email;
+        this.nickname = nickname;
+        this.password = password;
+        this.createdAt = Instant.now();
+        this.updatedAt = Instant.now();
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+        this.updatedAt = Instant.now();
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/user/entity/User.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/entity/User.java
@@ -28,7 +28,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
-    @Column(nullable = false, unique = true, length = 100)
+    @Column(nullable = false, length = 100)
     private String email;
 
     @Column(nullable = false, length = 50)

--- a/src/main/java/com/codeit/team4/deokhugam/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.codeit.team4.deokhugam.user.repository;
+
+import com.codeit.team4.deokhugam.user.entity.User;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+
+}

--- a/src/main/java/com/codeit/team4/deokhugam/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/repository/UserRepository.java
@@ -1,9 +1,15 @@
 package com.codeit.team4.deokhugam.user.repository;
 
 import com.codeit.team4.deokhugam.user.entity.User;
+import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
-
+    Optional<User> findByIdAndDeletedAtIsNull(UUID id);
+    Optional<User> findByEmailAndDeletedAtIsNull(String email);
+    boolean existsByEmailAndDeletedAtIsNull(String email);
+    Page<User> findAllByDeletedAtIsNull(Pageable pageable);
 }


### PR DESCRIPTION
## 관련 이슈
- closes 
  - #10 
  - #22 

## 작업 내용
- 사용자(User) 도메인 패키지 구조 설계
- User 엔티티 생성 및 기본 필드 정의 (email, nickname, password, createdAt, updatedAt, deletedAt)
- soft delete 구조 반영 (deletedAt 기반)
- UserRepository 인터페이스 생성 (JPA 기반 기본 구조)

## 변경 사항
- user 도메인 기본 구조 (entity / repository / package) 구성 완료
- DB 테이블(users) 구조에 맞춘 엔티티 설계 적용
- UUID 기반 PK 전략 적용 (GenerationType.UUID)
- 원래는 도메인 페키지 설계랑 엔티티 정의를 진행하고, 레포지토리는 JPA만 설정했는데, 
리뷰 부분에서 리포지토리에 메서드를 추가적으로 작성하라고 요청이 들어와서 작성 진행 했습니다.
- 해당 메서드에 대한 테스트는 바로 다음 이슈에서 진행해보도록 하겠습니다.
- BaseEntity, BaseUpdatableEntity 추가와 그에 따른 User.java 수정을 진행했습니다.

## 테스트 내용
- [x] 프로젝트 정상 빌드 확인
- [x] Spring Boot 실행 확인

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- Entity 설계가 DB DDL 기준과 적절히 매핑되었는지 확인 부탁드립니다.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자 계정 모델 도입: 이메일, 닉네임, 비밀번호와 생성/수정 타임스탬프 지원.
  * 계정 비활성화(소프트 삭제) 지원 및 비활성 계정 숨김 여부 확인 기능 추가.
  * 이메일 중복 확인 및 이메일/ID 기반 조회, 비활성 계정 제외한 페이징 조회 지원.

* **Chores**
  * JPA 감사(Auditing) 활성화 및 공통 엔티티 기반구조 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->