### PR TITLE
feat: 글로벌 예외 처리 및 에러 코드 구조 추가

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/global/error/BusinessException.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/error/BusinessException.java
@@ -1,0 +1,19 @@
+package com.codeit.team4.deokhugam.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String logMessage) {
+        super(logMessage);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
@@ -1,0 +1,17 @@
+package com.codeit.team4.deokhugam.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Common
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
 
     // Common
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다"),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다");
 
     private final HttpStatus status;

--- a/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorResponse.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorResponse.java
@@ -1,7 +1,7 @@
 package com.codeit.team4.deokhugam.global.error;
 
 public record ErrorResponse(
-        String code,
+        String errorCode,
         String message
 ) {
 }

--- a/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorResponse.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorResponse.java
@@ -1,0 +1,7 @@
+package com.codeit.team4.deokhugam.global.error;
+
+public record ErrorResponse(
+        String code,
+        String message
+) {
+}

--- a/src/main/java/com/codeit/team4/deokhugam/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/error/GlobalExceptionHandler.java
@@ -2,7 +2,6 @@ package com.codeit.team4.deokhugam.global.error;
 
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -45,7 +44,7 @@ public class GlobalExceptionHandler {
         );
 
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
+                .status(ErrorCode.INVALID_INPUT.getStatus())
                 .body(response);
     }
 
@@ -59,11 +58,11 @@ public class GlobalExceptionHandler {
 
         ErrorResponse response = new ErrorResponse(
                 ErrorCode.INVALID_INPUT.name(),
-                e.getMessage()
+                ErrorCode.INVALID_INPUT.getMessage()
         );
 
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
+                .status(ErrorCode.INVALID_INPUT.getStatus())
                 .body(response);
     }
 
@@ -72,11 +71,13 @@ public class GlobalExceptionHandler {
         log.warn("[NOT_FOUND] {}", e.getMessage());
 
         ErrorResponse response = new ErrorResponse(
-                "NOT_FOUND",
-                "요청한 리소스를 찾을 수 없습니다"
+                ErrorCode.NOT_FOUND.name(),
+                ErrorCode.NOT_FOUND.getMessage()
         );
 
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+        return ResponseEntity
+                .status(ErrorCode.NOT_FOUND.getStatus())
+                .body(response);
     }
 
     @ExceptionHandler(Exception.class)
@@ -87,6 +88,8 @@ public class GlobalExceptionHandler {
                 ErrorCode.INTERNAL_SERVER_ERROR.name(),
                 ErrorCode.INTERNAL_SERVER_ERROR.getMessage()
         );
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(response);
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,92 @@
+package com.codeit.team4.deokhugam.global.error;
+
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        log.warn("[{}] {}", errorCode.name(), e.getMessage());
+
+        ErrorResponse response = new ErrorResponse(
+                errorCode.name(),
+                errorCode.getMessage()
+        );
+
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+        String detail = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+
+        log.warn("[INVALID_INPUT] {}", detail);
+
+        ErrorResponse response = new ErrorResponse(
+                ErrorCode.INVALID_INPUT.name(),
+                detail
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(response);
+    }
+
+    @ExceptionHandler({
+            MissingServletRequestParameterException.class,
+            HttpMessageNotReadableException.class,
+            MethodArgumentTypeMismatchException.class
+    })
+    public ResponseEntity<ErrorResponse> handleBadRequestException(Exception e) {
+        log.warn("[INVALID_INPUT] {}", e.getMessage());
+
+        ErrorResponse response = new ErrorResponse(
+                ErrorCode.INVALID_INPUT.name(),
+                e.getMessage()
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(response);
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFoundException(NoResourceFoundException e) {
+        log.warn("[NOT_FOUND] {}", e.getMessage());
+
+        ErrorResponse response = new ErrorResponse(
+                "NOT_FOUND",
+                "요청한 리소스를 찾을 수 없습니다"
+        );
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("[INTERNAL_SERVER_ERROR] {}", e.getMessage(), e);
+
+        ErrorResponse response = new ErrorResponse(
+                ErrorCode.INTERNAL_SERVER_ERROR.name(),
+                ErrorCode.INTERNAL_SERVER_ERROR.getMessage()
+        );
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- closes #43

## 작업 내용
- 예외 처리를 위해 `GlobalExceptionHandler`를 구현하였습니다.
- `userId`와 같은 내부 식별자는 로그에 추가하고 클라이언트 응답에 노출되지 않도록 구현하였습니다.

## 변경 사항
- BusinessException
- ErrorCode
- ErrorResponse
- GlobalExceptionHandler 

## 테스트 내용
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 전역 에러 처리 도입으로 API 실패 시 일관된 에러 응답 제공
  * 입력 오류, 요청 누락/형식 오류에 대해 400 상태 및 상세 필드 오류 정보 반환
  * 존재하지 않는 리소스에 대해 404 상태 반환
  * 예기치 않은 서버 오류에 대해 500 상태 및 표준화된 오류 메시지 반환

* **기타 작업**
  * 에러 코드별 표준 메시지 및 HTTP 상태 코드 정립
<!-- end of auto-generated comment: release notes by coderabbit.ai -->