### PR TITLE
feat: 리뷰 도메인 구조 및 Swagger 설정 추가

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/global/config/SwaggerConfig.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.codeit.team4.deokhugam.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Deokhugam API")
+                        .description("덕후감 API 문서")
+                        .version("v1.0.0"));
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
@@ -11,7 +11,10 @@ public enum ErrorCode {
     // Common
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다"),
     NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다"),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다"),
+
+    // Review
+    INVALID_RATING(HttpStatus.BAD_REQUEST, "평점은 1~5 사이여야 합니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/codeit/team4/deokhugam/review/controller/ReviewController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/controller/ReviewController.java
@@ -3,9 +3,11 @@ package com.codeit.team4.deokhugam.review.controller;
 import com.codeit.team4.deokhugam.review.controller.api.ReviewApi;
 import com.codeit.team4.deokhugam.review.service.ReviewService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/reviews")
 @RequiredArgsConstructor

--- a/src/main/java/com/codeit/team4/deokhugam/review/controller/ReviewController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/controller/ReviewController.java
@@ -1,0 +1,16 @@
+package com.codeit.team4.deokhugam.review.controller;
+
+import com.codeit.team4.deokhugam.review.controller.api.ReviewApi;
+import com.codeit.team4.deokhugam.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/reviews")
+@RequiredArgsConstructor
+public class ReviewController implements ReviewApi {
+
+    private final ReviewService reviewService;
+
+}

--- a/src/main/java/com/codeit/team4/deokhugam/review/controller/api/ReviewApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/controller/api/ReviewApi.java
@@ -1,0 +1,8 @@
+package com.codeit.team4.deokhugam.review.controller.api;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "리뷰 관리", description = "리뷰 관련 API")
+public interface ReviewApi {
+
+}

--- a/src/main/java/com/codeit/team4/deokhugam/review/entity/Review.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/entity/Review.java
@@ -8,6 +8,7 @@ import com.codeit.team4.deokhugam.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -19,7 +20,15 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "reviews")
+@Table(
+        name = "reviews",
+        indexes = {
+                @Index(name = "idx_reviews_created_at", columnList = "created_at"),
+                @Index(name = "idx_reviews_rating", columnList = "rating"),
+                @Index(name = "idx_reviews_user_id", columnList = "user_id"),
+                @Index(name = "idx_reviews_deleted_at", columnList = "deleted_at")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review extends BaseUpdatableEntity {
 

--- a/src/main/java/com/codeit/team4/deokhugam/review/entity/Review.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/entity/Review.java
@@ -1,0 +1,75 @@
+package com.codeit.team4.deokhugam.review.entity;
+
+import com.codeit.team4.deokhugam.book.entity.Book;
+import com.codeit.team4.deokhugam.global.entity.BaseUpdatableEntity;
+import com.codeit.team4.deokhugam.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "reviews")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review extends BaseUpdatableEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = false)
+    private int rating;
+
+    @Column(nullable = false)
+    private int likeCount;
+
+    @Column(nullable = false)
+    private int commentCount;
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
+    public Review(Book book, User user, String content, int rating) {
+        this.book = book;
+        this.user = user;
+        this.content = content;
+        this.rating = rating;
+        this.likeCount = 0;
+        this.commentCount = 0;
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Review other)) {
+            return false;
+        }
+        return getId() != null && getId().equals(other.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getId());
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/review/entity/Review.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/entity/Review.java
@@ -2,6 +2,8 @@ package com.codeit.team4.deokhugam.review.entity;
 
 import com.codeit.team4.deokhugam.book.entity.Book;
 import com.codeit.team4.deokhugam.global.entity.BaseUpdatableEntity;
+import com.codeit.team4.deokhugam.global.error.BusinessException;
+import com.codeit.team4.deokhugam.global.error.ErrorCode;
 import com.codeit.team4.deokhugam.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -20,6 +22,9 @@ import lombok.NoArgsConstructor;
 @Table(name = "reviews")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review extends BaseUpdatableEntity {
+
+    private static final int MIN_RATING = 1;
+    private static final int MAX_RATING = 5;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "book_id", nullable = false)
@@ -45,12 +50,22 @@ public class Review extends BaseUpdatableEntity {
     private Instant deletedAt;
 
     public Review(Book book, User user, String content, int rating) {
+        validateRating(rating);
         this.book = book;
         this.user = user;
         this.content = content;
         this.rating = rating;
         this.likeCount = 0;
         this.commentCount = 0;
+    }
+
+    private void validateRating(int rating) {
+        if (rating < MIN_RATING || rating > MAX_RATING) {
+            throw new BusinessException(
+                    ErrorCode.INVALID_RATING,
+                    "rating=" + rating
+            );
+        }
     }
 
     public boolean isDeleted() {

--- a/src/main/java/com/codeit/team4/deokhugam/review/repository/ReviewRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/repository/ReviewRepository.java
@@ -1,0 +1,9 @@
+package com.codeit.team4.deokhugam.review.repository;
+
+import com.codeit.team4.deokhugam.review.entity.Review;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, UUID> {
+
+}

--- a/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
@@ -1,0 +1,13 @@
+package com.codeit.team4.deokhugam.review.service;
+
+import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+}

--- a/src/main/resources/db/migration/V2__add_reviews_deleted_at_index.sql
+++ b/src/main/resources/db/migration/V2__add_reviews_deleted_at_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_reviews_deleted_at ON reviews (deleted_at) WHERE deleted_at IS NOT NULL;


### PR DESCRIPTION
## 관련 이슈
- closes #17

## 작업 내용
- 리뷰 관리 도메인 관련 클래스 구현
- `SwaggerConfig` 추가

## 변경 사항
  - 리뷰 도메인 패키지 구조 생성 (controller, service, repository, entity)                                                                                                                                                                      
  - `Review` 엔티티 JPA 매핑                                                                                                                                                                                                        
  - Swagger API 문서 설정 추가                                                                                                                                                                                                                  
  - `ReviewApi` 인터페이스로 Swagger 명세 분리          
  - `V2__add_reviews_deleted_at_index.sql` deleted_at 인덱스 추가 

## 테스트 내용
- [ ] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.
