### PR TITLE
feat: 응답 헤더에 식별자 추가 로직 구현 및 로그 출력 포맷 정의

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/global/controller/HealthCheckController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/controller/HealthCheckController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/v1/health")
+@RequestMapping("/api/health")
 @RequiredArgsConstructor
 public class HealthCheckController implements HealthCheckApi {
 

--- a/src/main/java/com/codeit/team4/deokhugam/global/filter/LoggingFilter.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/filter/LoggingFilter.java
@@ -8,7 +8,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.MDC;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -21,6 +20,7 @@ public class LoggingFilter extends OncePerRequestFilter {
 
     public static final String REQUEST_ID_KEY = "request_id";
     public static final String CLIENT_IP_KEY = "client_ip";
+    public static final String RESPONSE_HEADER_REQUEST_ID = "X-Request-Id";
 
     private final List<String> ipHeaderCandidates;
 
@@ -43,6 +43,9 @@ public class LoggingFilter extends OncePerRequestFilter {
         request.setAttribute(CLIENT_IP_KEY, clientIp);
         MDC.put(REQUEST_ID_KEY, requestId);
         MDC.put(CLIENT_IP_KEY, clientIp);
+
+        // 응답 반환 전 헤더에 고유 요청 ID 주입
+        response.setHeader(RESPONSE_HEADER_REQUEST_ID, requestId);
 
         try {
             // 다음 필터 또는 컨트롤러로 요청 전달

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,12 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+  <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - [%X{request_id:-SYSTEM}] [%X{client_ip:-NONE}] %msg%n" />
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - [REQ: %X{request_id}] [IP: %X{client_ip}] %msg%n</pattern>
+      <pattern>${LOG_PATTERN}</pattern>
     </encoder>
   </appender>
 
-  <root level="INFO">
-    <appender-ref ref="CONSOLE" />
-  </root>
+  <springProfile name="local, test">
+    <root level="INFO">
+      <appender-ref ref="CONSOLE" />
+    </root>
+    <logger name="com.codeit.team4.deokhugam" level="DEBUG" />
+  </springProfile>
+
+  <springProfile name="prod">
+    <root level="INFO">
+      <appender-ref ref="CONSOLE" />
+    </root>
+    <logger name="com.codeit.team4.deokhugam" level="INFO" />
+  </springProfile>
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -7,7 +7,7 @@
     </encoder>
   </appender>
 
-  <springProfile name="local, test">
+  <springProfile name="!prod">
     <root level="INFO">
       <appender-ref ref="CONSOLE" />
     </root>

--- a/src/test/java/com/codeit/team4/deokhugam/DeokhugamApplicationTests.java
+++ b/src/test/java/com/codeit/team4/deokhugam/DeokhugamApplicationTests.java
@@ -15,15 +15,14 @@ import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.codeit.team4.deokhugam.global.filter.LoggingFilter;
+
 @Slf4j
 @SpringBootTest
 @Import(TestContainerConfig.class)
 @ActiveProfiles("test")
 @ExtendWith(OutputCaptureExtension.class)
 class DeokhugamApplicationTests {
-
-    public static final String REQUEST_ID_KEY = "request_id";
-    public static final String CLIENT_IP_KEY = "client_ip";
 
     @Test
     void contextLoads() {
@@ -36,8 +35,8 @@ class DeokhugamApplicationTests {
         String testRequestId = UUID.randomUUID().toString();
         String testClientIp = "192.168.0.1";
 
-        MDC.put(REQUEST_ID_KEY, testRequestId);
-        MDC.put(CLIENT_IP_KEY, testClientIp);
+        MDC.put(LoggingFilter.REQUEST_ID_KEY, testRequestId);
+        MDC.put(LoggingFilter.CLIENT_IP_KEY, testClientIp);
 
         // when
         log.info("요청 단위 로그 추적을 위한 테스트 메시지입니다.");

--- a/src/test/java/com/codeit/team4/deokhugam/DeokhugamApplicationTests.java
+++ b/src/test/java/com/codeit/team4/deokhugam/DeokhugamApplicationTests.java
@@ -1,18 +1,54 @@
 package com.codeit.team4.deokhugam;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.codeit.team4.deokhugam.config.TestContainerConfig;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.MDC;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+@Slf4j
 @SpringBootTest
 @Import(TestContainerConfig.class)
 @ActiveProfiles("test")
+@ExtendWith(OutputCaptureExtension.class)
 class DeokhugamApplicationTests {
+
+    public static final String REQUEST_ID_KEY = "request_id";
+    public static final String CLIENT_IP_KEY = "client_ip";
 
     @Test
     void contextLoads() {
+    }
+
+    @Test
+    @DisplayName("로그 출력 시 MDC 식별자와 IP가 지정된 전역 포맷으로 포함 성공")
+    void logFormat_containsMdcInformation(CapturedOutput output) {
+        // given
+        String testRequestId = UUID.randomUUID().toString();
+        String testClientIp = "192.168.0.1";
+
+        MDC.put(REQUEST_ID_KEY, testRequestId);
+        MDC.put(CLIENT_IP_KEY, testClientIp);
+
+        // when
+        log.info("요청 단위 로그 추적을 위한 테스트 메시지입니다.");
+
+        // then
+        MDC.clear(); // 검증 전 MDC 안전하게 초기화
+
+        // logback-spring.xml 설정에 의해 [request_id] [client_ip] 포맷이 적용되었는지 검증
+        assertThat(output.getOut()).contains("요청 단위 로그 추적을 위한 테스트 메시지입니다.");
+        assertThat(output.getOut()).contains("[" + testRequestId + "]");
+        assertThat(output.getOut()).contains("[" + testClientIp + "]");
     }
 
 }

--- a/src/test/java/com/codeit/team4/deokhugam/DeokhugamApplicationTests.java
+++ b/src/test/java/com/codeit/team4/deokhugam/DeokhugamApplicationTests.java
@@ -50,5 +50,23 @@ class DeokhugamApplicationTests {
         assertThat(output.getOut()).contains("[" + testClientIp + "]");
     }
 
+    // Spring Boot 처음 실행 시, 혹은 백그라운드 스케줄러(배치) 구동 시
+    // HTTP 요청이 없어 필터를 거치지 않아 MDC가 비어있는 경우 테스트
+    @Test
+    @DisplayName("MDC 값이 없을 때 fallback 포맷(-SYSTEM, -NONE) 적용 성공")
+    void logFormat_appliesFallback_whenMdcIsEmpty(CapturedOutput output) {
+        // given
+        MDC.clear(); // HTTP 요청이 아닌 내부 스케줄러/시스템 로직 상황을 가정하여 MDC를 완전히 비움
+
+        // when
+        log.info("MDC가 없는 백그라운드 배치의 로그 메시지입니다.");
+
+        // then
+        // logback-spring.xml의 `:-SYSTEM`, `:-NONE` 설정이 정상 작동하여 기본값이 찍히는지 검증
+        assertThat(output.getOut()).contains("MDC가 없는 백그라운드 배치의 로그 메시지입니다.");
+        assertThat(output.getOut()).contains("[SYSTEM]");
+        assertThat(output.getOut()).contains("[NONE]");
+    }
+
 }
 

--- a/src/test/java/com/codeit/team4/deokhugam/global/filter/LoggingFilterTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/global/filter/LoggingFilterTest.java
@@ -122,6 +122,10 @@ class LoggingFilterTest {
         // 예외가 발생했어도 2개의 Key 모두 안전하게 지워졌는지 검증 (메모리 누수 방지 실패 케이스 검증)
         assertThat(MDC.get(LoggingFilter.REQUEST_ID_KEY)).isNull();
         assertThat(MDC.get(LoggingFilter.CLIENT_IP_KEY)).isNull();
+
+        // 예외가 발생했어도 응답 객체에 포함된 헤더들은 클라이언트에게 전달되어야 함
+        assertThat(response.getHeader(LoggingFilter.RESPONSE_HEADER_REQUEST_ID)).isNotBlank();
+        assertThat(UUID.fromString(response.getHeader(LoggingFilter.RESPONSE_HEADER_REQUEST_ID))).isNotNull();
     }
 
     @Test
@@ -145,6 +149,10 @@ class LoggingFilterTest {
         // 런타임 예외가 밖으로 던져졌음에도 finally 블록이 정상 작동하여 MDC를 비웠는지 검증
         assertThat(MDC.get(LoggingFilter.REQUEST_ID_KEY)).isNull();
         assertThat(MDC.get(LoggingFilter.CLIENT_IP_KEY)).isNull();
+
+        // 예외가 발생했어도 응답 객체에 포함된 헤더들은 클라이언트에게 전달되어야 함
+        assertThat(response.getHeader(LoggingFilter.RESPONSE_HEADER_REQUEST_ID)).isNotBlank();
+        assertThat(UUID.fromString(response.getHeader(LoggingFilter.RESPONSE_HEADER_REQUEST_ID))).isNotNull();
     }
 
     @Test

--- a/src/test/java/com/codeit/team4/deokhugam/global/filter/LoggingFilterTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/global/filter/LoggingFilterTest.java
@@ -29,7 +29,7 @@ class LoggingFilterTest {
     );
 
     @Test
-    @DisplayName("기본 접속 시 IP 및 식별자 MDC 저장 성공")
+    @DisplayName("기본 접속 시 IP와 식별자 MDC 저장, 응답 헤더 반환 성공")
     void doFilterInternal_withRemoteAddr_Success() throws Exception {
         // given
         LoggingFilter loggingFilter = new LoggingFilter(new AppProperties(TEST_IP_HEADERS));
@@ -52,6 +52,8 @@ class LoggingFilterTest {
         assertThat(mdcRequestId[0]).isNotNull();
         assertThat(UUID.fromString(mdcRequestId[0])).isNotNull();
         assertThat(mdcClientIp[0]).isEqualTo("192.168.0.1");
+
+        assertThat(response.getHeader(LoggingFilter.RESPONSE_HEADER_REQUEST_ID)).isEqualTo(mdcRequestId[0]);
 
         assertThat(MDC.get(LoggingFilter.REQUEST_ID_KEY)).isNull();
         assertThat(MDC.get(LoggingFilter.CLIENT_IP_KEY)).isNull();


### PR DESCRIPTION
## 관련 이슈
- closes #39 
- closes #33 
- closes #30 

## 작업 내용
- 응답 헤더에 요청 식별자 추가 로직 구현
- 최종 응답 반환 전 헤더 주입 처리
- 로그 레벨 사용 기준 수립 : logback-spring.xml

## 변경 사항
- prod 환경에서는 로그 레벨을 INFO까지, 그 이외에는 DEBUG까지 허용
- LoggingFilter.java에서 ip, request_id 이외에 응답 헤더 id까지 주입

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [ ] 코드 컨벤션을 지켰습니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [ ] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **주요 변경사항**
  * 헬스 체크 엔드포인트 경로가 변경되었습니다.
  * 모든 응답에 요청 추적용 ID 헤더(X-Request-Id)가 추가되었습니다.
  * 로깅 형식이 개선되었고, 개발/프로덕션 환경별 로깅 레벨이 적용됩니다.

* **테스트**
  * 로그 출력 및 요청 ID 헤더 관련 동작을 검증하는 통합/단위 테스트가 추가·확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->