### PR TITLE
feat: 사용자 회원가입(Create) 및 사용자 조회(Read) 구현

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다"),
 
     // Review
     INVALID_RATING(HttpStatus.BAD_REQUEST, "평점은 1~5 사이여야 합니다"),

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
@@ -1,9 +1,13 @@
 package com.codeit.team4.deokhugam.user.service;
 
+import com.codeit.team4.deokhugam.user.dto.UserRegisterRequest;
+import com.codeit.team4.deokhugam.user.dto.UserResponse;
 import com.codeit.team4.deokhugam.user.entity.User;
 import java.util.UUID;
 
 public interface UserService {
+
+    UserResponse registerUser(UserRegisterRequest request);
 
     User findById(UUID userId);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
@@ -10,6 +10,7 @@ import com.codeit.team4.deokhugam.user.repository.UserRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,16 +27,20 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public UserResponse registerUser(UserRegisterRequest request) {
 
-        log.info("회원가입 요청: email={}", request.email());
-
         validateEmailNotExists(request.email());
 
-        User user = userMapper.toEntity(request);
-        User savedUser = userRepository.save(user);
+        try {
+            User user = userMapper.toEntity(request);
+            User savedUser = userRepository.save(user);
 
-        log.info("회원가입 완료: userId={}", savedUser.getId());
+            log.info("회원가입 성공: userId={}", savedUser.getId());
 
-        return userMapper.toResponse(savedUser);
+            return userMapper.toResponse(savedUser);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(
+                    ErrorCode.DUPLICATE_EMAIL,
+                    "email=" + request.email());
+        }
     }
 
     @Override

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
@@ -2,24 +2,53 @@ package com.codeit.team4.deokhugam.user.service;
 
 import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.global.error.ErrorCode;
+import com.codeit.team4.deokhugam.user.dto.UserRegisterRequest;
+import com.codeit.team4.deokhugam.user.dto.UserResponse;
 import com.codeit.team4.deokhugam.user.entity.User;
+import com.codeit.team4.deokhugam.user.mapper.UserMapper;
 import com.codeit.team4.deokhugam.user.repository.UserRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final UserMapper userMapper;
+
+    @Override
+    @Transactional
+    public UserResponse registerUser(UserRegisterRequest request) {
+
+        log.info("회원가입 요청: email={}", request.email());
+
+        validateEmailNotExists(request.email());
+
+        User user = userMapper.toEntity(request);
+        User savedUser = userRepository.save(user);
+
+        log.info("회원가입 완료: userId={}", savedUser.getId());
+
+        return userMapper.toResponse(savedUser);
+    }
 
     @Override
     public User findById(UUID userId) {
         return userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(
                         ErrorCode.USER_NOT_FOUND, "userId=" + userId));
+    }
+
+    // 헬퍼 메서드
+    private void validateEmailNotExists(String email) {
+        if (userRepository.existsByEmailAndDeletedAtIsNull(email)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_EMAIL);
+        }
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
@@ -1,0 +1,125 @@
+package com.codeit.team4.deokhugam.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.codeit.team4.deokhugam.global.error.BusinessException;
+import com.codeit.team4.deokhugam.global.error.ErrorCode;
+import com.codeit.team4.deokhugam.user.dto.UserRegisterRequest;
+import com.codeit.team4.deokhugam.user.dto.UserResponse;
+import com.codeit.team4.deokhugam.user.entity.User;
+import com.codeit.team4.deokhugam.user.mapper.UserMapper;
+import com.codeit.team4.deokhugam.user.repository.UserRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    @Test
+    @DisplayName("회원가입 성공")
+    void registerUser_success() {
+        // given
+        UserRegisterRequest request = new UserRegisterRequest(
+                "test@test.com",
+                "user1",
+                "password1!"
+        );
+        User user = new User("test@test.com", "user1", "password1!");
+        User savedUser = new User("test@test.com", "user1", "password1!");
+
+        when(userRepository.existsByEmailAndDeletedAtIsNull(request.email()))
+                .thenReturn(false);
+        when(userMapper.toEntity(request)).thenReturn(user);
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+        when(userMapper.toResponse(any(User.class)))
+                .thenReturn(new UserResponse(null, "test@test.com", "user1", null));
+
+        // when
+        UserResponse result = userService.registerUser(request);
+
+        // then
+        assertThat(result)
+                .extracting(UserResponse::email, UserResponse::nickname)
+                .contains(request.email(), request.nickname());
+
+        verify(userMapper).toEntity(request);
+        verify(userRepository).save(user);
+        verify(userMapper).toResponse(savedUser);
+    }
+
+    @Test
+    @DisplayName("이메일 중복으로 인한 회원가입 실패")
+    void registerUser_fail_duplicate_email() {
+        // given
+        UserRegisterRequest request = new UserRegisterRequest(
+                "test@test.com",
+                "user1",
+                "password1!"
+        );
+
+        when(userRepository.existsByEmailAndDeletedAtIsNull(request.email()))
+                .thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> userService.registerUser(request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DUPLICATE_EMAIL);
+
+        verify(userMapper, never()).toEntity(any());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("유저 조회 성공")
+    void findById_success() {
+        // given
+        UUID userId = UUID.randomUUID();
+        User user = new User("test@test.com", "user1", "password1!");
+
+        when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                .thenReturn(Optional.of(user));
+
+        // when
+        User result = userService.findById(userId);
+
+        // then
+        assertThat(result).isEqualTo(user);
+    }
+
+    @Test
+    @DisplayName("유저 조회 실패")
+    void findById_fail() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.findById(userId))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
@@ -3,6 +3,7 @@ package com.codeit.team4.deokhugam.user.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceImplTest {
@@ -88,6 +90,36 @@ class UserServiceImplTest {
 
         verify(userMapper, never()).toEntity(any());
         verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("DB 무결성 위반으로 회원가입 실패")
+    void registerUser_fail_dataIntegrityViolation() {
+        // given
+        UserRegisterRequest request = new UserRegisterRequest(
+                "test@test.com",
+                "user1",
+                "password1!"
+        );
+
+        User user = mock(User.class);
+
+        when(userRepository.existsByEmailAndDeletedAtIsNull(request.email()))
+                .thenReturn(false);
+
+        when(userMapper.toEntity(request)).thenReturn(user);
+
+        when(userRepository.save(any(User.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate"));
+
+        // when & then
+        assertThatThrownBy(() -> userService.registerUser(request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DUPLICATE_EMAIL);
+
+        verify(userMapper).toEntity(request);
+        verify(userRepository).save(user);
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
- closes #46 

## 작업 내용
- [x] UserService 인터페이스 및 구현체 작성
- [x] 회원가입 비즈니스 로직 구현
- [x] 사용자 조회 로직 구현
- [x] 예외 처리 추가
  - 중복 이메일 발생 시 BusinessException 처리
- [x] 단위 테스트 작성
  - 회원가입 성공 케이스
  - 이메일 중복 실패 케이스
  - 유저 조회 성공/실패 케이스

## 변경 사항
- 시연님께서 작성해주신 `findById` 메서드에 대한 테스트 코드도 작성하였습니다.
- 코드래빗 피드백을 반영하여서 회원가입 메서드에 `DataIntegrityViolationException` 예외처리를 추가하고 그와 관련된 테스트 코드를 추가했습니다.

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 등록 기능 추가: 새로운 이메일 주소로 계정을 생성할 수 있습니다.
  * 이메일 중복 검증: 이미 존재하는 이메일로 가입하려는 경우 명확한 오류 메시지를 표시합니다.

* **테스트**
  * 사용자 등록 및 조회 기능에 대한 포괄적인 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->