### PR TITLE
feat: 리뷰 논리, 물리 삭제 구현

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/review/controller/ReviewController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/controller/ReviewController.java
@@ -11,10 +11,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -48,5 +48,27 @@ public class ReviewController implements ReviewApi {
         ReviewResponse response = reviewService.updateReview(reviewId, userId, request);
 
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<Void> softDeleteReview(
+            @PathVariable UUID reviewId,
+            @RequestHeader("Deokhugam-Request-User-ID") UUID userId
+    ) {
+        log.info("리뷰 논리 삭제 요청: reviewId={}, userId={}", reviewId, userId);
+        reviewService.softDeleteReview(reviewId, userId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{reviewId}/hard")
+    public ResponseEntity<Void> hardDeleteReview(
+            @PathVariable UUID reviewId,
+            @RequestHeader("Deokhugam-Request-User-ID") UUID userId
+    ) {
+        log.info("리뷰 물리 삭제 요청: reviewId={}, userId={}", reviewId, userId);
+        reviewService.hardDeleteReview(reviewId, userId);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/review/controller/api/ReviewApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/controller/api/ReviewApi.java
@@ -59,4 +59,38 @@ public interface ReviewApi {
             @Parameter(description = "리뷰 수정 요청 정보", required = true)
             @RequestBody ReviewUpdateRequest request
     );
+
+    @Operation(summary = "리뷰 삭제", description = "본인이 작성한 리뷰를 삭제합니다")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "리뷰 삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "본인의 리뷰가 아님",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<Void> softDeleteReview(
+            @Parameter(description = "리뷰 ID", required = true, example = "123e4567-e89b-12d3-a456-426614174000")
+            @PathVariable UUID reviewId,
+            @Parameter(description = "요청자 ID", required = true, example = "123e4567-e89b-12d3-a456-426614174000")
+            @RequestHeader("Deokhugam-Request-User-ID") UUID userId
+    );
+
+    @Operation(summary = "리뷰 물리 삭제", description = "본인이 작성한 리뷰를 영구적으로 삭제합니다")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "리뷰 물리 삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "본인의 리뷰가 아님",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<Void> hardDeleteReview(
+            @Parameter(description = "리뷰 ID", required = true, example = "123e4567-e89b-12d3-a456-426614174000")
+            @PathVariable UUID reviewId,
+            @Parameter(description = "요청자 ID", required = true, example = "123e4567-e89b-12d3-a456-426614174000")
+            @RequestHeader("Deokhugam-Request-User-ID") UUID userId
+    );
 }

--- a/src/main/java/com/codeit/team4/deokhugam/review/controller/api/ReviewApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/controller/api/ReviewApi.java
@@ -20,15 +20,15 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "리뷰 관리", description = "리뷰 관련 API")
 public interface ReviewApi {
 
-    @Operation(summary = "리뷰 생성", description = "도서에 대한 리뷰를 작성합니다")
+    @Operation(summary = "리뷰 등록", description = "새로운 리뷰를 등록합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "리뷰 생성 성공",
+            @ApiResponse(responseCode = "201", description = "리뷰 등록 성공",
                     content = @Content(schema = @Schema(implementation = ReviewResponse.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 입력",
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "도서 또는 사용자를 찾을 수 없음",
+            @ApiResponse(responseCode = "404", description = "도서 정보 없음",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "409", description = "이미 리뷰를 작성함",
+            @ApiResponse(responseCode = "409", description = "이미 작성된 리뷰 존재",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
@@ -38,15 +38,15 @@ public interface ReviewApi {
             @RequestBody ReviewCreateRequest request
     );
 
-    @Operation(summary = "리뷰 수정", description = "본인이 작성한 리뷰를 수정합니다")
+    @Operation(summary = "리뷰 수정", description = "본인이 작성한 리뷰를 수정합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "리뷰 수정 성공",
                     content = @Content(schema = @Schema(implementation = ReviewResponse.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 입력",
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "403", description = "본인의 리뷰가 아님",
+            @ApiResponse(responseCode = "403", description = "리뷰 수정 권한 없음",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없음",
+            @ApiResponse(responseCode = "404", description = "리뷰 정보 없음",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
@@ -60,12 +60,14 @@ public interface ReviewApi {
             @RequestBody ReviewUpdateRequest request
     );
 
-    @Operation(summary = "리뷰 삭제", description = "본인이 작성한 리뷰를 삭제합니다")
+    @Operation(summary = "리뷰 논리 삭제", description = "본인이 작성한 리뷰를 논리적으로 삭제합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "리뷰 삭제 성공"),
-            @ApiResponse(responseCode = "403", description = "본인의 리뷰가 아님",
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (요청자 ID 누락)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없음",
+            @ApiResponse(responseCode = "403", description = "리뷰 삭제 권한 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "리뷰 정보 없음",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
@@ -77,12 +79,14 @@ public interface ReviewApi {
             @RequestHeader("Deokhugam-Request-User-ID") UUID userId
     );
 
-    @Operation(summary = "리뷰 물리 삭제", description = "본인이 작성한 리뷰를 영구적으로 삭제합니다")
+    @Operation(summary = "리뷰 물리 삭제", description = "본인이 작성한 리뷰를 물리적으로 삭제합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "리뷰 물리 삭제 성공"),
-            @ApiResponse(responseCode = "403", description = "본인의 리뷰가 아님",
+            @ApiResponse(responseCode = "204", description = "리뷰 삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (요청자 ID 누락)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "리뷰를 찾을 수 없음",
+            @ApiResponse(responseCode = "403", description = "리뷰 삭제 권한 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "리뷰 정보 없음",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))

--- a/src/main/java/com/codeit/team4/deokhugam/review/entity/Review.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/entity/Review.java
@@ -74,6 +74,10 @@ public class Review extends BaseUpdatableEntity {
         this.rating = rating;
     }
 
+    public void softDelete() {
+        this.deletedAt = Instant.now();
+    }
+
     public boolean isOwner(User user) {
         return this.user.equals(user);
     }

--- a/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
@@ -13,4 +13,10 @@ public interface ReviewService {
     ReviewResponse updateReview(UUID reviewId, UUID userId, ReviewUpdateRequest request);
 
     Review findById(UUID reviewId);
+
+    Review findWithDeletedById(UUID reviewId);
+
+    void softDeleteReview(UUID reviewId, UUID userId);
+
+    void hardDeleteReview(UUID reviewId, UUID userId);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewServiceImpl.java
@@ -61,6 +61,13 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     @Override
+    public Review findWithDeletedById(UUID reviewId) {
+        return reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new BusinessException(
+                        ErrorCode.REVIEW_NOT_FOUND, "reviewId=" + reviewId));
+    }
+
+    @Override
     @Transactional
     public ReviewResponse updateReview(UUID reviewId, UUID userId, ReviewUpdateRequest request) {
         User user = userService.findById(userId);
@@ -73,6 +80,28 @@ public class ReviewServiceImpl implements ReviewService {
 
         boolean likedByMe = reviewLikeRepository.existsByReviewIdAndUserId(reviewId, userId);
         return reviewMapper.toResponse(review, likedByMe);
+    }
+
+    @Override
+    @Transactional
+    public void softDeleteReview(UUID reviewId, UUID userId) {
+        User user = userService.findById(userId);
+        Review review = findById(reviewId);
+
+        validateReviewOwner(review, user);
+        review.softDelete();
+        log.info("리뷰 논리 삭제 완료: reviewId={}", review.getId());
+    }
+
+    @Override
+    @Transactional
+    public void hardDeleteReview(UUID reviewId, UUID userId) {
+        User user = userService.findById(userId);
+        Review review = findWithDeletedById(reviewId);
+
+        validateReviewOwner(review, user);
+        reviewRepository.delete(review);
+        log.info("리뷰 물리 삭제 완료: reviewId={}", review.getId());
     }
 
     private void validateDuplicateReview(UUID bookId, UUID userId) {

--- a/src/test/java/com/codeit/team4/deokhugam/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/controller/ReviewControllerTest.java
@@ -3,6 +3,9 @@ package com.codeit.team4.deokhugam.review.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -298,6 +301,105 @@ class ReviewControllerTest {
                             .header(USER_ID_HEADER, userId.toString())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.errorCode").value("REVIEW_NOT_FOUND"));
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 삭제")
+    class DeleteReview {
+
+        private static final String USER_ID_HEADER = "Deokhugam-Request-User-ID";
+
+        @Test
+        @DisplayName("리뷰 삭제 성공")
+        void softDeleteReview_success() throws Exception {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+
+            doNothing().when(reviewService).softDeleteReview(reviewId, userId);
+
+            mockMvc.perform(delete("/api/reviews/{reviewId}", reviewId)
+                            .header(USER_ID_HEADER, userId.toString()))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("본인의 리뷰가 아니면 삭제 실패")
+        void softDeleteReview_notOwner_fail() throws Exception {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+
+            doThrow(new BusinessException(ErrorCode.REVIEW_NOT_OWNER))
+                    .when(reviewService).softDeleteReview(reviewId, userId);
+
+            mockMvc.perform(delete("/api/reviews/{reviewId}", reviewId)
+                            .header(USER_ID_HEADER, userId.toString()))
+                    .andDo(print())
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.errorCode").value("REVIEW_NOT_OWNER"));
+        }
+
+        @Test
+        @DisplayName("리뷰 물리 삭제 성공")
+        void hardDeleteReview_success() throws Exception {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+
+            doNothing().when(reviewService).hardDeleteReview(reviewId, userId);
+
+            mockMvc.perform(delete("/api/reviews/{reviewId}/hard", reviewId)
+                            .header(USER_ID_HEADER, userId.toString()))
+                    .andDo(print())
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("본인의 리뷰가 아니면 물리 삭제 실패")
+        void hardDeleteReview_notOwner_fail() throws Exception {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+
+            doThrow(new BusinessException(ErrorCode.REVIEW_NOT_OWNER))
+                    .when(reviewService).hardDeleteReview(reviewId, userId);
+
+            mockMvc.perform(delete("/api/reviews/{reviewId}/hard", reviewId)
+                            .header(USER_ID_HEADER, userId.toString()))
+                    .andDo(print())
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.errorCode").value("REVIEW_NOT_OWNER"));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리뷰 물리 삭제 실패")
+        void hardDeleteReview_notFound_fail() throws Exception {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+
+            doThrow(new BusinessException(ErrorCode.REVIEW_NOT_FOUND))
+                    .when(reviewService).hardDeleteReview(reviewId, userId);
+
+            mockMvc.perform(delete("/api/reviews/{reviewId}/hard", reviewId)
+                            .header(USER_ID_HEADER, userId.toString()))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.errorCode").value("REVIEW_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리뷰 삭제 실패")
+        void softDeleteReview_notFound_fail() throws Exception {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+
+            doThrow(new BusinessException(ErrorCode.REVIEW_NOT_FOUND))
+                    .when(reviewService).softDeleteReview(reviewId, userId);
+
+            mockMvc.perform(delete("/api/reviews/{reviewId}", reviewId)
+                            .header(USER_ID_HEADER, userId.toString()))
                     .andDo(print())
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.errorCode").value("REVIEW_NOT_FOUND"));

--- a/src/test/java/com/codeit/team4/deokhugam/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/repository/ReviewRepositoryTest.java
@@ -9,6 +9,7 @@ import com.codeit.team4.deokhugam.global.config.JpaAuditingConfig;
 import com.codeit.team4.deokhugam.review.entity.Review;
 import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.repository.UserRepository;
+import com.codeit.team4.deokhugam.review.entity.ReviewLike;
 import java.time.LocalDate;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +29,9 @@ class ReviewRepositoryTest {
 
     @Autowired
     private ReviewRepository reviewRepository;
+
+    @Autowired
+    private ReviewLikeRepository reviewLikeRepository;
 
     @Autowired
     private UserRepository userRepository;
@@ -120,6 +124,52 @@ class ReviewRepositoryTest {
             Optional<Review> result = reviewRepository.findByIdAndDeletedAtIsNull(review.getId());
 
             assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("소프트 삭제된 리뷰 findById 조회")
+    class FindWithDeletedById {
+
+        @Test
+        @DisplayName("소프트 삭제된 리뷰도 findById로 조회 성공")
+        void findById_softDeleted_success() {
+            Review review = reviewRepository.save(new Review(book, user, "좋은 책입니다", 5));
+
+            entityManager.getEntityManager()
+                    .createQuery("UPDATE Review r SET r.deletedAt = CURRENT_TIMESTAMP WHERE r.id = :id")
+                    .setParameter("id", review.getId())
+                    .executeUpdate();
+            entityManager.flush();
+            entityManager.clear();
+
+            Optional<Review> result = reviewRepository.findById(review.getId());
+
+            assertThat(result).isPresent();
+            assertThat(result.get().getContent()).isEqualTo("좋은 책입니다");
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 물리 삭제 시 연관 객체 CASCADE 삭제")
+    class HardDeleteCascade {
+        //TODO: 댓글 삭제도 확인
+
+        @Test
+        @DisplayName("리뷰 삭제 시 좋아요도 함께 삭제 성공")
+        void hardDelete_cascadeDeletesReviewLikes() {
+            Review review = reviewRepository.save(new Review(book, user, "좋은 책입니다", 5));
+            ReviewLike like = new ReviewLike(review, user);
+            entityManager.persist(like);
+            entityManager.flush();
+            entityManager.clear();
+
+            reviewRepository.deleteById(review.getId());
+            entityManager.flush();
+            entityManager.clear();
+
+            assertThat(reviewRepository.findById(review.getId())).isEmpty();
+            assertThat(reviewLikeRepository.findById(like.getId())).isEmpty();
         }
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewServiceImplTest.java
@@ -220,8 +220,17 @@ class ReviewServiceImplTest {
             Review review = mock(Review.class);
             ReviewUpdateRequest request = new ReviewUpdateRequest("수정된 내용", 3);
             ReviewResponse expectedResponse = new ReviewResponse(
-                    reviewId, UUID.randomUUID(), "클린 코드", null,
-                    userId, "테스터", "수정된 내용", 3, 0, 0, true,
+                    reviewId,
+                    UUID.randomUUID(),
+                    "클린 코드",
+                    null,
+                    userId,
+                    "테스터",
+                    "수정된 내용",
+                    3,
+                    0,
+                    0,
+                    true,
                     Instant.now(),
                     Instant.now()
             );
@@ -289,6 +298,169 @@ class ReviewServiceImplTest {
                     .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
 
             assertThatThrownBy(() -> reviewService.updateReview(reviewId, userId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.USER_NOT_FOUND));
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 삭제")
+    class SoftDeleteReview {
+
+        @Test
+        @DisplayName("리뷰 삭제 성공")
+        void softDeleteReview_success() {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            User user = mock(User.class);
+            Review review = mock(Review.class);
+
+            given(userService.findById(userId)).willReturn(user);
+            given(reviewRepository.findByIdAndDeletedAtIsNull(reviewId)).willReturn(Optional.of(review));
+            given(review.isOwner(user)).willReturn(true);
+
+            reviewService.softDeleteReview(reviewId, userId);
+
+            verify(review).softDelete();
+        }
+
+        @Test
+        @DisplayName("본인의 리뷰가 아니면 삭제 실패")
+        void softDeleteReview_notOwner_fail() {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            User user = mock(User.class);
+            Review review = mock(Review.class);
+
+            given(userService.findById(userId)).willReturn(user);
+            given(reviewRepository.findByIdAndDeletedAtIsNull(reviewId)).willReturn(Optional.of(review));
+            given(review.isOwner(user)).willReturn(false);
+            given(review.getId()).willReturn(reviewId);
+            given(user.getId()).willReturn(userId);
+
+            assertThatThrownBy(() -> reviewService.softDeleteReview(reviewId, userId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.REVIEW_NOT_OWNER));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리뷰 삭제 실패")
+        void softDeleteReview_notFound_fail() {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            User user = mock(User.class);
+
+            given(userService.findById(userId)).willReturn(user);
+            given(reviewRepository.findByIdAndDeletedAtIsNull(reviewId)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> reviewService.softDeleteReview(reviewId, userId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.REVIEW_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자로 리뷰 삭제 실패")
+        void softDeleteReview_userNotFound_fail() {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+
+            given(userService.findById(userId))
+                    .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+            assertThatThrownBy(() -> reviewService.softDeleteReview(reviewId, userId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.USER_NOT_FOUND));
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 물리 삭제")
+    class HardDeleteReview {
+
+        @Test
+        @DisplayName("리뷰 물리 삭제 성공")
+        void hardDeleteReview_success() {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            User user = mock(User.class);
+            Review review = mock(Review.class);
+
+            given(userService.findById(userId)).willReturn(user);
+            given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+            given(review.isOwner(user)).willReturn(true);
+
+            reviewService.hardDeleteReview(reviewId, userId);
+
+            verify(reviewRepository).delete(review);
+        }
+
+        @Test
+        @DisplayName("소프트 삭제된 리뷰 물리 삭제 성공")
+        void hardDeleteReview_softDeleted_success() {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            User user = mock(User.class);
+            Review review = mock(Review.class);
+
+            given(userService.findById(userId)).willReturn(user);
+            given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+            given(review.isOwner(user)).willReturn(true);
+
+            reviewService.hardDeleteReview(reviewId, userId);
+
+            verify(reviewRepository).delete(review);
+        }
+
+        @Test
+        @DisplayName("본인의 리뷰가 아니면 물리 삭제 실패")
+        void hardDeleteReview_notOwner_fail() {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            User user = mock(User.class);
+            Review review = mock(Review.class);
+
+            given(userService.findById(userId)).willReturn(user);
+            given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+            given(review.isOwner(user)).willReturn(false);
+            given(review.getId()).willReturn(reviewId);
+            given(user.getId()).willReturn(userId);
+
+            assertThatThrownBy(() -> reviewService.hardDeleteReview(reviewId, userId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.REVIEW_NOT_OWNER));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리뷰 물리 삭제 실패")
+        void hardDeleteReview_notFound_fail() {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            User user = mock(User.class);
+
+            given(userService.findById(userId)).willReturn(user);
+            given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> reviewService.hardDeleteReview(reviewId, userId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.REVIEW_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자로 리뷰 물리 삭제 실패")
+        void hardDeleteReview_userNotFound_fail() {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+
+            given(userService.findById(userId))
+                    .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+            assertThatThrownBy(() -> reviewService.hardDeleteReview(reviewId, userId))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.USER_NOT_FOUND));

--- a/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewServiceImplTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewServiceImplTest.java
@@ -399,23 +399,6 @@ class ReviewServiceImplTest {
         }
 
         @Test
-        @DisplayName("소프트 삭제된 리뷰 물리 삭제 성공")
-        void hardDeleteReview_softDeleted_success() {
-            UUID reviewId = UUID.randomUUID();
-            UUID userId = UUID.randomUUID();
-            User user = mock(User.class);
-            Review review = mock(Review.class);
-
-            given(userService.findById(userId)).willReturn(user);
-            given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
-            given(review.isOwner(user)).willReturn(true);
-
-            reviewService.hardDeleteReview(reviewId, userId);
-
-            verify(reviewRepository).delete(review);
-        }
-
-        @Test
         @DisplayName("본인의 리뷰가 아니면 물리 삭제 실패")
         void hardDeleteReview_notOwner_fail() {
             UUID reviewId = UUID.randomUUID();


### PR DESCRIPTION
## 관련 이슈
- closes #21

## 작업 내용
- 리뷰 논리, 물리 삭제를 구현했습니다
- 댓글 도메인이 없는 상태라 댓글 도메인 삭제 테스트 추가 예정 입니다

## 변경 사항
- 주요 변경 사항을 작성해주세요.

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 리뷰 삭제 기능 추가: 일시 삭제(데이터 보존)와 완전 삭제(영구 제거) 두 가지 옵션 제공
  * 사용자는 자신의 리뷰를 두 가지 방식으로 삭제 가능

* **테스트**
  * 리뷰 삭제 기능에 대한 포괄적인 테스트 케이스 추가
  * 권한 검증 및 오류 처리 테스트 구현

<!-- end of auto-generated comment: release notes by coderabbit.ai -->