### PR TITLE
feat: 사용자 물리 삭제 구현

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/global/config/SchedulingConfig.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/config/SchedulingConfig.java
@@ -1,9 +1,11 @@
 package com.codeit.team4.deokhugam.global.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
 @EnableScheduling
+@Profile("!test")
 public class SchedulingConfig {
 }

--- a/src/main/java/com/codeit/team4/deokhugam/global/config/SchedulingConfig.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.codeit.team4.deokhugam.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/codeit/team4/deokhugam/user/repository/UserJooqRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/repository/UserJooqRepository.java
@@ -1,0 +1,22 @@
+package com.codeit.team4.deokhugam.user.repository;
+
+import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserJooqRepository {
+
+    private final DSLContext dsl;
+
+    public int deleteExpiredUsers(Instant threshold) {
+        return dsl.deleteFrom(USERS)
+                .where(USERS.DELETED_AT.lt(threshold.atOffset(ZoneOffset.UTC)))
+                .execute();
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package com.codeit.team4.deokhugam.user.repository;
 
 import com.codeit.team4.deokhugam.user.entity.User;
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -12,4 +14,5 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByEmailAndDeletedAtIsNull(String email);
     boolean existsByEmailAndDeletedAtIsNull(String email);
     Page<User> findAllByDeletedAtIsNull(Pageable pageable);
+    List<User> findAllByDeletedAtBefore(Instant time);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/repository/UserRepository.java
@@ -1,8 +1,6 @@
 package com.codeit.team4.deokhugam.user.repository;
 
 import com.codeit.team4.deokhugam.user.entity.User;
-import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/codeit/team4/deokhugam/user/repository/UserRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/repository/UserRepository.java
@@ -14,5 +14,4 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     Optional<User> findByEmailAndDeletedAtIsNull(String email);
     boolean existsByEmailAndDeletedAtIsNull(String email);
     Page<User> findAllByDeletedAtIsNull(Pageable pageable);
-    List<User> findAllByDeletedAtBefore(Instant time);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/user/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/scheduler/UserCleanupScheduler.java
@@ -15,6 +15,12 @@ public class UserCleanupScheduler {
 
     @Scheduled(cron = "${user.cleanup.cron}")
     public void runCleanup() {
-        userService.deleteExpiredUsers();
+        log.info("유저 물리 삭제 스케줄러 시작");
+        try {
+            userService.deleteExpiredUsers();
+            log.info("유저 물리 삭제 스케줄러 완료");
+        } catch (Exception e) {
+            log.error("유저 물리 삭제 스케줄러 실패", e);
+        }
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/user/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/scheduler/UserCleanupScheduler.java
@@ -13,7 +13,7 @@ public class UserCleanupScheduler {
 
     private final UserService userService;
 
-    @Scheduled(fixedRate = 300000)
+    @Scheduled(fixedRateString = "${user.cleanup.fixed-rate}")
     public void runCleanup() {
         userService.deleteExpiredUsers();
     }

--- a/src/main/java/com/codeit/team4/deokhugam/user/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/scheduler/UserCleanupScheduler.java
@@ -13,7 +13,7 @@ public class UserCleanupScheduler {
 
     private final UserService userService;
 
-    @Scheduled(fixedRateString = "${user.cleanup.fixed-rate}")
+    @Scheduled(cron = "${user.cleanup.cron}")
     public void runCleanup() {
         userService.deleteExpiredUsers();
     }

--- a/src/main/java/com/codeit/team4/deokhugam/user/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/scheduler/UserCleanupScheduler.java
@@ -1,0 +1,20 @@
+package com.codeit.team4.deokhugam.user.scheduler;
+
+import com.codeit.team4.deokhugam.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserCleanupScheduler {
+
+    private final UserService userService;
+
+    @Scheduled(fixedRate = 300000)
+    public void runCleanup() {
+        userService.deleteExpiredUsers();
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
@@ -18,4 +18,6 @@ public interface UserService {
     UserResponse updateUser(UUID userId, UserUpdateRequest request);
 
     void deleteUser(UUID userId);
+
+    void deleteExpiredUsers();
 }

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
@@ -8,10 +8,10 @@ import com.codeit.team4.deokhugam.user.dto.UserResponse;
 import com.codeit.team4.deokhugam.user.dto.UserUpdateRequest;
 import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.mapper.UserMapper;
+import com.codeit.team4.deokhugam.user.repository.UserJooqRepository;
 import com.codeit.team4.deokhugam.user.repository.UserRepository;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final UserJooqRepository userJooqRepository;
     private final UserMapper userMapper;
 
     @Override
@@ -97,11 +98,9 @@ public class UserServiceImpl implements UserService {
 
         Instant threshold = Instant.now().minus(1, ChronoUnit.DAYS);
 
-        List<User> users = userRepository.findAllByDeletedAtBefore(threshold);
+        int deletedCount = userJooqRepository.deleteExpiredUsers(threshold);
 
-        userRepository.deleteAll(users);
-
-        log.info("유저 물리 삭제 완료: count={}", users.size());
+        log.info("유저 물리 삭제 완료: count={}, threshold={}", deletedCount, threshold);
     }
 
     // 헬퍼 메서드

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
@@ -9,6 +9,9 @@ import com.codeit.team4.deokhugam.user.dto.UserUpdateRequest;
 import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.mapper.UserMapper;
 import com.codeit.team4.deokhugam.user.repository.UserRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -86,6 +89,19 @@ public class UserServiceImpl implements UserService {
         user.softDelete();
 
         log.info("유저 삭제 완료: userId={}", userId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteExpiredUsers() {
+
+        Instant threshold = Instant.now().minus(1, ChronoUnit.DAYS);
+
+        List<User> users = userRepository.findAllByDeletedAtBefore(threshold);
+
+        userRepository.deleteAll(users);
+
+        log.info("유저 물리 삭제 완료: count={}", users.size());
     }
 
     // 헬퍼 메서드

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -19,3 +19,4 @@ logging:
 user:
   cleanup:
     cron: "0 */5 * * * *"
+    zone: "Asia/Seoul"

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -15,3 +15,7 @@ logging:
     com.codeit.team4: DEBUG
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+
+user:
+  cleanup:
+    cron: "0 */5 * * * *"

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -17,3 +17,4 @@ logging:
 user:
   cleanup:
     cron: "0 0 4 * * *"
+    zone: "Asia/Seoul"

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -13,3 +13,7 @@ logging:
   level:
     root: WARN
     com.codeit.team4: INFO
+
+user:
+  cleanup:
+    cron: "0 0 4 * * *"

--- a/src/test/java/com/codeit/team4/deokhugam/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/repository/UserRepositoryTest.java
@@ -90,31 +90,6 @@ class UserRepositoryTest {
                 );
     }
 
-    @Test
-    @DisplayName("삭제 기준 시간 이전 사용자 조회 성공")
-    void findAllByDeletedAtBefore_success() {
-        // given
-        Instant now = Instant.now();
-
-        User oldUser = saveUser("old@test.com", "old");
-        markAsDeleted(oldUser, now.minus(2, ChronoUnit.DAYS)); // 기준 이전
-
-        User recentUser = saveUser("recent@test.com", "recent");
-        markAsDeleted(recentUser, now.minus(1, ChronoUnit.HOURS)); // 기준 이후
-
-        // when
-        List<User> result = userRepository.findAllByDeletedAtBefore(
-                now.minus(1, ChronoUnit.DAYS)
-        );
-
-        // then
-        assertThat(result).hasSize(1);
-
-        assertThat(result)
-                .extracting(User::getEmail)
-                .containsExactly("old@test.com");
-    }
-
     // --- 실패 케이스 ---
 
     @Test
@@ -174,27 +149,6 @@ class UserRepositoryTest {
         // then
         assertThat(result.getContent()).isEmpty();
         assertThat(result.getTotalElements()).isEqualTo(0);
-    }
-
-    @Test
-    @DisplayName("삭제 기준 시간 이전 사용자가 없어 조회 실패")
-    void findAllByDeletedAtBefore_fail() {
-        // given
-        Instant now = Instant.now();
-
-        User recentUser1 = saveUser("recent1@test.com", "recent1");
-        markAsDeleted(recentUser1, now.minus(1, ChronoUnit.HOURS));
-
-        User recentUser2 = saveUser("recent2@test.com", "recent2");
-        markAsDeleted(recentUser2, now.minus(30, ChronoUnit.MINUTES));
-
-        // when
-        List<User> result = userRepository.findAllByDeletedAtBefore(
-                now.minus(1, ChronoUnit.DAYS)
-        );
-
-        // then
-        assertThat(result).isEmpty();
     }
 
     // --- 헬퍼 메소드 ---

--- a/src/test/java/com/codeit/team4/deokhugam/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/repository/UserRepositoryTest.java
@@ -177,7 +177,6 @@ class UserRepositoryTest {
      * 영속성 컨텍스트를 동기화하고,
      * 지정한 시간으로 deletedAt을 설정하여 소프트 딜리트 상태로 변경한다
      */
-
     private void markAsDeleted(User user, Instant deletedAt) {
         em.flush();
         em.getEntityManager()

--- a/src/test/java/com/codeit/team4/deokhugam/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/repository/UserRepositoryTest.java
@@ -6,6 +6,8 @@ import com.codeit.team4.deokhugam.config.TestContainerConfig;
 import com.codeit.team4.deokhugam.global.config.JpaAuditingConfig;
 import com.codeit.team4.deokhugam.user.entity.User;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -88,6 +90,31 @@ class UserRepositoryTest {
                 );
     }
 
+    @Test
+    @DisplayName("삭제 기준 시간 이전 사용자 조회 성공")
+    void findAllByDeletedAtBefore_success() {
+        // given
+        Instant now = Instant.now();
+
+        User oldUser = saveUser("old@test.com", "old");
+        markAsDeleted(oldUser, now.minus(2, ChronoUnit.DAYS)); // 기준 이전
+
+        User recentUser = saveUser("recent@test.com", "recent");
+        markAsDeleted(recentUser, now.minus(1, ChronoUnit.HOURS)); // 기준 이후
+
+        // when
+        List<User> result = userRepository.findAllByDeletedAtBefore(
+                now.minus(1, ChronoUnit.DAYS)
+        );
+
+        // then
+        assertThat(result).hasSize(1);
+
+        assertThat(result)
+                .extracting(User::getEmail)
+                .containsExactly("old@test.com");
+    }
+
     // --- 실패 케이스 ---
 
     @Test
@@ -149,6 +176,27 @@ class UserRepositoryTest {
         assertThat(result.getTotalElements()).isEqualTo(0);
     }
 
+    @Test
+    @DisplayName("삭제 기준 시간 이전 사용자가 없어 조회 실패")
+    void findAllByDeletedAtBefore_fail() {
+        // given
+        Instant now = Instant.now();
+
+        User recentUser1 = saveUser("recent1@test.com", "recent1");
+        markAsDeleted(recentUser1, now.minus(1, ChronoUnit.HOURS));
+
+        User recentUser2 = saveUser("recent2@test.com", "recent2");
+        markAsDeleted(recentUser2, now.minus(30, ChronoUnit.MINUTES));
+
+        // when
+        List<User> result = userRepository.findAllByDeletedAtBefore(
+                now.minus(1, ChronoUnit.DAYS)
+        );
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
     // --- 헬퍼 메소드 ---
 
     /**
@@ -166,6 +214,21 @@ class UserRepositoryTest {
         em.getEntityManager()
                 .createQuery("update User u set u.deletedAt = :now where u.id = :id")
                 .setParameter("now", Instant.now())
+                .setParameter("id", user.getId())
+                .executeUpdate();
+        em.clear();
+    }
+
+    /**
+     * 영속성 컨텍스트를 동기화하고,
+     * 지정한 시간으로 deletedAt을 설정하여 소프트 딜리트 상태로 변경한다
+     */
+
+    private void markAsDeleted(User user, Instant deletedAt) {
+        em.flush();
+        em.getEntityManager()
+                .createQuery("update User u set u.deletedAt = :time where u.id = :id")
+                .setParameter("time", deletedAt)
                 .setParameter("id", user.getId())
                 .executeUpdate();
         em.clear();

--- a/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
@@ -16,7 +16,10 @@ import com.codeit.team4.deokhugam.user.dto.UserResponse;
 import com.codeit.team4.deokhugam.user.dto.UserUpdateRequest;
 import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.mapper.UserMapper;
+import com.codeit.team4.deokhugam.user.repository.UserJooqRepository;
 import com.codeit.team4.deokhugam.user.repository.UserRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -24,6 +27,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -34,6 +38,9 @@ class UserServiceImplTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private UserJooqRepository userJooqRepository;
 
     @Mock
     private UserMapper userMapper;
@@ -304,31 +311,18 @@ class UserServiceImplTest {
     @Test
     @DisplayName("삭제 대상 사용자 물리 삭제 성공")
     void deleteExpiredUsers_success() {
-        // given
-        User user1 = new User("old1@test.com", "user1", "pw");
-        User user2 = new User("old2@test.com", "user2", "pw");
-
-        when(userRepository.findAllByDeletedAtBefore(any()))
-                .thenReturn(List.of(user1, user2));
-
         // when
         userService.deleteExpiredUsers();
 
         // then
-        verify(userRepository).deleteAll(List.of(user1, user2));
-    }
+        ArgumentCaptor<Instant> captor = ArgumentCaptor.forClass(Instant.class);
 
-    @Test
-    @DisplayName("삭제 대상 사용자가 없어 빈 리스트 삭제")
-    void deleteExpiredUsers_no_target() {
-        // given
-        when(userRepository.findAllByDeletedAtBefore(any()))
-                .thenReturn(Collections.emptyList());
+        verify(userJooqRepository).deleteExpiredUsers(captor.capture());
 
-        // when
-        userService.deleteExpiredUsers();
+        Instant threshold = captor.getValue();
 
-        // then
-        verify(userRepository).deleteAll(Collections.emptyList());
+        assertThat(threshold)
+                .isBeforeOrEqualTo(Instant.now())
+                .isAfter(Instant.now().minus(2, ChronoUnit.DAYS));
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
@@ -3,6 +3,7 @@ package com.codeit.team4.deokhugam.user.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -340,5 +341,19 @@ class UserServiceImplTest {
         // then
         verify(userJooqRepository).deleteExpiredUsers(any(Instant.class));
         verifyNoMoreInteractions(userJooqRepository);
+    }
+
+    @Test
+    @DisplayName("JOOQ 저장소 예외 발생 시 물리 삭제 실패")
+    void deleteExpiredUsers_fail_repository_exception() {
+        // given
+        doThrow(new RuntimeException("DB error"))
+                .when(userJooqRepository).deleteExpiredUsers(any());
+
+        // when & then
+        assertThatThrownBy(() -> userService.deleteExpiredUsers())
+                .isInstanceOf(RuntimeException.class);
+
+        verify(userJooqRepository).deleteExpiredUsers(any());
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.codeit.team4.deokhugam.global.error.BusinessException;
@@ -320,9 +321,24 @@ class UserServiceImplTest {
         verify(userJooqRepository).deleteExpiredUsers(captor.capture());
 
         Instant threshold = captor.getValue();
+        Instant now = Instant.now();
 
         assertThat(threshold)
-                .isBeforeOrEqualTo(Instant.now())
-                .isAfter(Instant.now().minus(2, ChronoUnit.DAYS));
+                .isBeforeOrEqualTo(now)
+                .isAfter(now.minus(1, ChronoUnit.DAYS).minusSeconds(5));
+    }
+
+    @Test
+    @DisplayName("삭제 대상 사용자가 없어도 물리 삭제 성공")
+    void deleteExpiredUsers_no_target_success() {
+        // given
+        when(userJooqRepository.deleteExpiredUsers(any())).thenReturn(0);
+
+        // when
+        userService.deleteExpiredUsers();
+
+        // then
+        verify(userJooqRepository).deleteExpiredUsers(any(Instant.class));
+        verifyNoMoreInteractions(userJooqRepository);
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
@@ -17,6 +17,8 @@ import com.codeit.team4.deokhugam.user.dto.UserUpdateRequest;
 import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.mapper.UserMapper;
 import com.codeit.team4.deokhugam.user.repository.UserRepository;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -297,5 +299,36 @@ class UserServiceImplTest {
                 .isEqualTo(ErrorCode.USER_NOT_FOUND);
 
         verify(userRepository).findByIdAndDeletedAtIsNull(userId);
+    }
+
+    @Test
+    @DisplayName("삭제 대상 사용자 물리 삭제 성공")
+    void deleteExpiredUsers_success() {
+        // given
+        User user1 = new User("old1@test.com", "user1", "pw");
+        User user2 = new User("old2@test.com", "user2", "pw");
+
+        when(userRepository.findAllByDeletedAtBefore(any()))
+                .thenReturn(List.of(user1, user2));
+
+        // when
+        userService.deleteExpiredUsers();
+
+        // then
+        verify(userRepository).deleteAll(List.of(user1, user2));
+    }
+
+    @Test
+    @DisplayName("삭제 대상 사용자가 없어 빈 리스트 삭제")
+    void deleteExpiredUsers_no_target() {
+        // given
+        when(userRepository.findAllByDeletedAtBefore(any()))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        userService.deleteExpiredUsers();
+
+        // then
+        verify(userRepository).deleteAll(Collections.emptyList());
     }
 }


### PR DESCRIPTION
## 관련 이슈
- closes #38 

## 작업 내용
- [x] 스케줄러 기능 추가 (SchedulingConfig)
- [x] 사용자 물리 삭제 배치 로직 구현
- [x] soft delete 기준 (deletedAt + 1일) 만료 데이터 삭제 로직 적용
- [x] JOOQ 기반 bulk delete 적용으로 성능 개선
- [x] JPA 기반 삭제 조회 로직 제거
- [x] cron 기반 스케줄링으로 변경
- [x] local / prod 환경별 cron 설정 분리
- [x] UserService - Scheduler 연동

## 변경 사항
- 스케줄러 활성화를 위해 `SchedulingConfig` 추가
  - `@Profile("!test")` 적용하여 테스트 환경에서는 스케줄러 실행 제외 (테스트 안정성 확보)
- cron 기반으로 변경
- 환경별 실행 주기 분리
  - local: 5분 (테스트 환경)
  - prod: 매일 새벽 4시 (운영 환경)
- JOOQ 기반 물리 삭제 적용
  - `UserRepository.findAllByDeletedAtBefore` 제거
  - `UserJooqRepository.deleteExpiredUsers()` 도입

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 만료된 사용자 계정의 자동 정리 기능이 추가되었습니다. 이제 시스템은 설정된 일정에 따라 자동으로 만료된 사용자를 정리합니다. (로컬: 5분마다, 프로덕션: 매일 오전 4시)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->