### PR TITLE
chore: jacoco 커버리지 측정에서 jooq 생성 코드 제외

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,8 @@ jobs:
       - name: Gradle 실행 권한 부여
         run: chmod +x gradlew
 
-      - name: 테스트 및 커버리지 체크 실행
-        run: ./gradlew test jacocoTestCoverageVerification -PgenerateJooq
-        continue-on-error: true
+      - name: 테스트 실행
+        run: ./gradlew test -PgenerateJooq
+
+      - name: 커버리지 체크
+        run: ./gradlew jacocoTestCoverageVerification -PgenerateJooq

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,4 +33,3 @@ jobs:
 
       - name: 커버리지 체크
         run: ./gradlew jacocoTestCoverageVerification -PgenerateJooq
-        continue-on-error: true

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,23 @@ jacocoTestReport {
         xml.required = true
         html.required = true
     }
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    '**/jooq/**'
+            ])
+        }))
+    }
 }
 
 jacocoTestCoverageVerification {
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    '**/jooq/**'
+            ])
+        }))
+    }
     violationRules {
         rule {
             limit {


### PR DESCRIPTION
## 관련 이슈
- closes #115 

## 작업 내용
- jacoco 커버리지 측정에서 jooq 생성 코드 제외
- 
- 

## 변경 사항
- 주요 변경 사항을 작성해주세요.

## 테스트 내용
- [ ] 테스트 코드 작성
- [ ] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [ ] 코드 컨벤션을 지켰습니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [ ] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 코드 커버리지 수집 구성에서 특정 경로를 제외하도록 재조정해 불필요한 파일이 집계되지 않게 했습니다.
* **Bug Fixes**
  * CI의 커버리지 검증 단계가 실패 시에도 계속 진행하지 않도록 변경되어, 검증 실패가 전체 빌드 실패로 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->