### PR TITLE
feat: 리뷰 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/review/controller/ReviewController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/controller/ReviewController.java
@@ -8,6 +8,7 @@ import com.codeit.team4.deokhugam.review.service.ReviewService;
 import org.springdoc.core.annotations.ParameterObject;
 import com.codeit.team4.deokhugam.review.controller.api.ReviewApi;
 import com.codeit.team4.deokhugam.review.dto.ReviewCreateRequest;
+import com.codeit.team4.deokhugam.review.dto.ReviewLikeResponse;
 import com.codeit.team4.deokhugam.review.dto.ReviewResponse;
 import com.codeit.team4.deokhugam.review.dto.ReviewSearchRequestParam;
 import com.codeit.team4.deokhugam.review.dto.ReviewUpdateRequest;
@@ -97,5 +98,16 @@ public class ReviewController implements ReviewApi {
         reviewService.hardDeleteReview(reviewId, user.userId());
 
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{reviewId}/like")
+    public ResponseEntity<ReviewLikeResponse> toggleLike(
+            @PathVariable UUID reviewId,
+            @LoginUser DeokhugamUser user
+    ) {
+        log.info("리뷰 좋아요 요청: reviewId={}, userId={}", reviewId, user.userId());
+        ReviewLikeResponse response = reviewService.toggleLike(reviewId, user.userId());
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/review/controller/api/ReviewApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/controller/api/ReviewApi.java
@@ -5,6 +5,7 @@ import com.codeit.team4.deokhugam.global.dto.DeokhugamUser;
 import com.codeit.team4.deokhugam.global.error.ErrorResponse;
 import com.codeit.team4.deokhugam.global.response.PageResponse;
 import com.codeit.team4.deokhugam.review.dto.ReviewCreateRequest;
+import com.codeit.team4.deokhugam.review.dto.ReviewLikeResponse;
 import com.codeit.team4.deokhugam.review.dto.ReviewResponse;
 import com.codeit.team4.deokhugam.review.dto.ReviewSearchRequestParam;
 import com.codeit.team4.deokhugam.review.dto.ReviewUpdateRequest;
@@ -130,6 +131,24 @@ public interface ReviewApi {
     })
     @Parameter(name = "Deokhugam-Request-User-ID", in = ParameterIn.HEADER, required = true, description = "요청자 ID", example = "123e4567-e89b-12d3-a456-426614174000")
     ResponseEntity<Void> hardDeleteReview(
+            @Parameter(description = "리뷰 ID", required = true, example = "123e4567-e89b-12d3-a456-426614174000")
+            @PathVariable UUID reviewId,
+            @LoginUser DeokhugamUser user
+    );
+
+    @Operation(summary = "리뷰 좋아요", description = "리뷰에 좋아요를 추가하거나 취소합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "리뷰 좋아요 성공",
+                    content = @Content(schema = @Schema(implementation = ReviewLikeResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (요청자 ID 누락)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "리뷰 정보 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @Parameter(name = "Deokhugam-Request-User-ID", in = ParameterIn.HEADER, required = true, description = "요청자 ID", example = "123e4567-e89b-12d3-a456-426614174000")
+    ResponseEntity<ReviewLikeResponse> toggleLike(
             @Parameter(description = "리뷰 ID", required = true, example = "123e4567-e89b-12d3-a456-426614174000")
             @PathVariable UUID reviewId,
             @LoginUser DeokhugamUser user

--- a/src/main/java/com/codeit/team4/deokhugam/review/dto/ReviewLikeResponse.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/dto/ReviewLikeResponse.java
@@ -1,0 +1,19 @@
+package com.codeit.team4.deokhugam.review.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+@Schema(description = "리뷰 좋아요 응답")
+public record ReviewLikeResponse(
+
+        @Schema(description = "리뷰 ID")
+        UUID reviewId,
+
+        @Schema(description = "사용자 ID")
+        UUID userId,
+
+        @Schema(description = "좋아요 여부")
+        boolean liked
+) {
+
+}

--- a/src/main/java/com/codeit/team4/deokhugam/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/repository/ReviewLikeRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, UUID> {
 
     boolean existsByReviewIdAndUserId(UUID reviewId, UUID userId);
+
+    void deleteByReviewIdAndUserId(UUID reviewId, UUID userId);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/repository/ReviewLikeRepository.java
@@ -8,5 +8,5 @@ public interface ReviewLikeRepository extends JpaRepository<ReviewLike, UUID> {
 
     boolean existsByReviewIdAndUserId(UUID reviewId, UUID userId);
 
-    void deleteByReviewIdAndUserId(UUID reviewId, UUID userId);
+    long deleteByReviewIdAndUserId(UUID reviewId, UUID userId);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/review/repository/ReviewRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/repository/ReviewRepository.java
@@ -19,4 +19,12 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Review r SET r.commentCount = r.commentCount + 1 WHERE r.id = :reviewId")
     void increaseCommentCount(@Param("reviewId") UUID reviewId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Review r SET r.likeCount = r.likeCount + 1 WHERE r.id = :reviewId")
+    void increaseLikeCount(@Param("reviewId") UUID reviewId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Review r SET r.likeCount = r.likeCount - 1 WHERE r.id = :reviewId AND r.likeCount > 0")
+    void decreaseLikeCount(@Param("reviewId") UUID reviewId);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
@@ -5,8 +5,10 @@ import com.codeit.team4.deokhugam.book.service.BookService;
 import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.global.error.ErrorCode;
 import com.codeit.team4.deokhugam.review.dto.ReviewCreateRequest;
+import com.codeit.team4.deokhugam.review.dto.ReviewLikeResponse;
 import com.codeit.team4.deokhugam.review.dto.ReviewResponse;
 import com.codeit.team4.deokhugam.review.dto.ReviewUpdateRequest;
+import com.codeit.team4.deokhugam.review.entity.ReviewLike;
 import com.codeit.team4.deokhugam.review.entity.Review;
 import com.codeit.team4.deokhugam.review.mapper.ReviewMapper;
 import com.codeit.team4.deokhugam.review.repository.ReviewLikeRepository;
@@ -104,6 +106,31 @@ public class ReviewService {
             throw new BusinessException(
                     ErrorCode.DUPLICATE_REVIEW, "bookId=" + bookId + ", userId=" + userId);
         }
+    }
+
+    @Transactional
+    public ReviewLikeResponse toggleLike(UUID reviewId, UUID userId) {
+        Review review = findById(reviewId);
+
+        if (reviewLikeRepository.existsByReviewIdAndUserId(reviewId, userId)) {
+            unlikeReview(reviewId, userId);
+            return new ReviewLikeResponse(reviewId, userId, false);
+        }
+
+        likeReview(review, userId);
+        return new ReviewLikeResponse(reviewId, userId, true);
+    }
+
+    private void likeReview(Review review, UUID userId) {
+        reviewLikeRepository.save(new ReviewLike(review, userService.findById(userId)));
+        reviewRepository.increaseLikeCount(review.getId());
+        log.info("리뷰 좋아요 추가: reviewId={}, userId={}", review.getId(), userId);
+    }
+
+    private void unlikeReview(UUID reviewId, UUID userId) {
+        reviewLikeRepository.deleteByReviewIdAndUserId(reviewId, userId);
+        reviewRepository.decreaseLikeCount(reviewId);
+        log.info("리뷰 좋아요 취소: reviewId={}, userId={}", reviewId, userId);
     }
 
     private boolean isLikedByUser(UUID reviewId, UUID userId) {

--- a/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
@@ -122,8 +122,13 @@ public class ReviewService {
     }
 
     private void likeReview(Review review, UUID userId) {
-        reviewLikeRepository.save(new ReviewLike(review, userService.findById(userId)));
-        reviewRepository.increaseLikeCount(review.getId());
+        try {
+            reviewLikeRepository.save(new ReviewLike(review, userService.findById(userId)));
+            reviewRepository.increaseLikeCount(review.getId());
+        } catch (DataIntegrityViolationException e) {
+            log.debug("이미 좋아요 상태: reviewId={}, userId={}", review.getId(), userId);
+            return;
+        }
         log.info("리뷰 좋아요 추가: reviewId={}, userId={}", review.getId(), userId);
     }
 

--- a/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
@@ -133,7 +133,11 @@ public class ReviewService {
     }
 
     private void unlikeReview(UUID reviewId, UUID userId) {
-        reviewLikeRepository.deleteByReviewIdAndUserId(reviewId, userId);
+        long deleted = reviewLikeRepository.deleteByReviewIdAndUserId(reviewId, userId);
+        if (deleted == 0) {
+            log.debug("이미 좋아요 취소 상태: reviewId={}, userId={}", reviewId, userId);
+            return;
+        }
         reviewRepository.decreaseLikeCount(reviewId);
         log.info("리뷰 좋아요 취소: reviewId={}, userId={}", reviewId, userId);
     }

--- a/src/test/java/com/codeit/team4/deokhugam/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/controller/ReviewControllerTest.java
@@ -18,6 +18,7 @@ import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.global.error.ErrorCode;
 import com.codeit.team4.deokhugam.global.response.PageResponse;
 import com.codeit.team4.deokhugam.review.dto.ReviewCreateRequest;
+import com.codeit.team4.deokhugam.review.dto.ReviewLikeResponse;
 import com.codeit.team4.deokhugam.review.dto.ReviewResponse;
 import com.codeit.team4.deokhugam.review.dto.ReviewSearchRequestParam;
 import com.codeit.team4.deokhugam.review.dto.ReviewUpdateRequest;
@@ -622,6 +623,73 @@ class ReviewControllerTest {
                     .andDo(print())
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.errorCode").value("REVIEW_NOT_FOUND"));
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 좋아요 토글")
+    class ToggleLike {
+
+        private static final String USER_ID_HEADER = "Deokhugam-Request-User-ID";
+
+        @Test
+        @DisplayName("좋아요 추가 성공")
+        void toggleLike_like_success() throws Exception {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            ReviewLikeResponse response = new ReviewLikeResponse(reviewId, userId, true);
+
+            given(reviewService.toggleLike(reviewId, userId)).willReturn(response);
+
+            mockMvc.perform(post("/api/reviews/{reviewId}/like", reviewId)
+                            .header(USER_ID_HEADER, userId.toString()))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.reviewId").value(reviewId.toString()))
+                    .andExpect(jsonPath("$.userId").value(userId.toString()))
+                    .andExpect(jsonPath("$.liked").value(true));
+        }
+
+        @Test
+        @DisplayName("좋아요 취소 성공")
+        void toggleLike_unlike_success() throws Exception {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            ReviewLikeResponse response = new ReviewLikeResponse(reviewId, userId, false);
+
+            given(reviewService.toggleLike(reviewId, userId)).willReturn(response);
+
+            mockMvc.perform(post("/api/reviews/{reviewId}/like", reviewId)
+                            .header(USER_ID_HEADER, userId.toString()))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.reviewId").value(reviewId.toString()))
+                    .andExpect(jsonPath("$.userId").value(userId.toString()))
+                    .andExpect(jsonPath("$.liked").value(false));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리뷰 좋아요 토글 실패")
+        void toggleLike_reviewNotFound_fail() throws Exception {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+
+            given(reviewService.toggleLike(reviewId, userId))
+                    .willThrow(new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
+
+            mockMvc.perform(post("/api/reviews/{reviewId}/like", reviewId)
+                            .header(USER_ID_HEADER, userId.toString()))
+                    .andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.errorCode").value("REVIEW_NOT_FOUND"));
+        }
+
+        @Test
+        @DisplayName("요청자 ID 누락 시 좋아요 토글 실패")
+        void toggleLike_missingHeader_fail() throws Exception {
+            mockMvc.perform(post("/api/reviews/{reviewId}/like", UUID.randomUUID()))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
         }
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/review/repository/ReviewLikeRepositoryTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/repository/ReviewLikeRepositoryTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -36,6 +37,9 @@ class ReviewLikeRepositoryTest {
 
     @Autowired
     private BookRepository bookRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
 
     private User user;
     private Review review;
@@ -80,6 +84,38 @@ class ReviewLikeRepositoryTest {
             boolean exists = reviewLikeRepository.existsByReviewIdAndUserId(
                     review.getId(), user.getId());
 
+            assertThat(exists).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("좋아요 삭제")
+    class DeleteByReviewIdAndUserId {
+
+        @Test
+        @DisplayName("좋아요 삭제 성공")
+        void deleteByReviewIdAndUserId_success() {
+            reviewLikeRepository.save(new ReviewLike(review, user));
+            entityManager.flush();
+            entityManager.clear();
+
+            reviewLikeRepository.deleteByReviewIdAndUserId(review.getId(), user.getId());
+            entityManager.flush();
+            entityManager.clear();
+
+            boolean exists = reviewLikeRepository.existsByReviewIdAndUserId(
+                    review.getId(), user.getId());
+            assertThat(exists).isFalse();
+        }
+
+        @Test
+        @DisplayName("좋아요가 없어도 삭제 시 에러 없음 성공")
+        void deleteByReviewIdAndUserId_noLike_success() {
+            reviewLikeRepository.deleteByReviewIdAndUserId(review.getId(), user.getId());
+            entityManager.flush();
+
+            boolean exists = reviewLikeRepository.existsByReviewIdAndUserId(
+                    review.getId(), user.getId());
             assertThat(exists).isFalse();
         }
     }

--- a/src/test/java/com/codeit/team4/deokhugam/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/repository/ReviewRepositoryTest.java
@@ -156,6 +156,67 @@ class ReviewRepositoryTest {
     }
 
     @Nested
+    @DisplayName("좋아요 수 증가")
+    class IncreaseLikeCount {
+
+        @Test
+        @DisplayName("좋아요 수 증가 성공")
+        void increaseLikeCount_success() {
+            Review review = reviewRepository.save(new Review(book, user, "좋은 책입니다", 5));
+
+            reviewRepository.increaseLikeCount(review.getId());
+            entityManager.clear();
+
+            Review found = reviewRepository.findById(review.getId()).get();
+            assertThat(found.getLikeCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("좋아요 수 연속 증가 성공")
+        void increaseLikeCount_multiple_success() {
+            Review review = reviewRepository.save(new Review(book, user, "좋은 책입니다", 5));
+
+            reviewRepository.increaseLikeCount(review.getId());
+            reviewRepository.increaseLikeCount(review.getId());
+            entityManager.clear();
+
+            Review found = reviewRepository.findById(review.getId()).get();
+            assertThat(found.getLikeCount()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("좋아요 수 감소")
+    class DecreaseLikeCount {
+
+        @Test
+        @DisplayName("좋아요 수 감소 성공")
+        void decreaseLikeCount_success() {
+            Review review = reviewRepository.save(new Review(book, user, "좋은 책입니다", 5));
+            reviewRepository.increaseLikeCount(review.getId());
+            entityManager.clear();
+
+            reviewRepository.decreaseLikeCount(review.getId());
+            entityManager.clear();
+
+            Review found = reviewRepository.findById(review.getId()).get();
+            assertThat(found.getLikeCount()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("좋아요 수 0 이하로 감소하지 않음 성공")
+        void decreaseLikeCount_notBelowZero_success() {
+            Review review = reviewRepository.save(new Review(book, user, "좋은 책입니다", 5));
+
+            reviewRepository.decreaseLikeCount(review.getId());
+            entityManager.clear();
+
+            Review found = reviewRepository.findById(review.getId()).get();
+            assertThat(found.getLikeCount()).isEqualTo(0);
+        }
+    }
+
+    @Nested
     @DisplayName("리뷰 물리 삭제 시 연관 객체 CASCADE 삭제")
     class HardDeleteCascade {
         @Test

--- a/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewServiceTest.java
@@ -419,6 +419,7 @@ class ReviewServiceTest {
 
             given(reviewRepository.findByIdAndDeletedAtIsNull(reviewId)).willReturn(Optional.of(review));
             given(reviewLikeRepository.existsByReviewIdAndUserId(reviewId, userId)).willReturn(true);
+            given(reviewLikeRepository.deleteByReviewIdAndUserId(reviewId, userId)).willReturn(1L);
 
             ReviewLikeResponse response = reviewService.toggleLike(reviewId, userId);
 

--- a/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewServiceTest.java
@@ -13,6 +13,7 @@ import com.codeit.team4.deokhugam.book.service.BookService;
 import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.global.error.ErrorCode;
 import com.codeit.team4.deokhugam.review.dto.ReviewCreateRequest;
+import com.codeit.team4.deokhugam.review.dto.ReviewLikeResponse;
 import com.codeit.team4.deokhugam.review.dto.ReviewResponse;
 import com.codeit.team4.deokhugam.review.dto.ReviewUpdateRequest;
 import com.codeit.team4.deokhugam.review.entity.Review;
@@ -377,6 +378,66 @@ class ReviewServiceTest {
             given(reviewRepository.findByIdAndDeletedAtIsNull(reviewId)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> reviewService.softDeleteReview(reviewId, userId))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.REVIEW_NOT_FOUND));
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 좋아요 토글")
+    class ToggleLike {
+
+        @Test
+        @DisplayName("좋아요 추가 성공")
+        void toggleLike_like_success() {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            Review review = mock(Review.class);
+            User user = mock(User.class);
+
+            given(reviewRepository.findByIdAndDeletedAtIsNull(reviewId)).willReturn(Optional.of(review));
+            given(reviewLikeRepository.existsByReviewIdAndUserId(reviewId, userId)).willReturn(false);
+            given(userService.findById(userId)).willReturn(user);
+            given(review.getId()).willReturn(reviewId);
+
+            ReviewLikeResponse response = reviewService.toggleLike(reviewId, userId);
+
+            assertThat(response.liked()).isTrue();
+            assertThat(response.reviewId()).isEqualTo(reviewId);
+            assertThat(response.userId()).isEqualTo(userId);
+            verify(reviewLikeRepository).save(any());
+            verify(reviewRepository).increaseLikeCount(reviewId);
+        }
+
+        @Test
+        @DisplayName("좋아요 취소 성공")
+        void toggleLike_unlike_success() {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            Review review = mock(Review.class);
+
+            given(reviewRepository.findByIdAndDeletedAtIsNull(reviewId)).willReturn(Optional.of(review));
+            given(reviewLikeRepository.existsByReviewIdAndUserId(reviewId, userId)).willReturn(true);
+
+            ReviewLikeResponse response = reviewService.toggleLike(reviewId, userId);
+
+            assertThat(response.liked()).isFalse();
+            assertThat(response.reviewId()).isEqualTo(reviewId);
+            assertThat(response.userId()).isEqualTo(userId);
+            verify(reviewLikeRepository).deleteByReviewIdAndUserId(reviewId, userId);
+            verify(reviewRepository).decreaseLikeCount(reviewId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리뷰 좋아요 토글 실패")
+        void toggleLike_reviewNotFound_fail() {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+
+            given(reviewRepository.findByIdAndDeletedAtIsNull(reviewId)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> reviewService.toggleLike(reviewId, userId))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.REVIEW_NOT_FOUND));


### PR DESCRIPTION
## 관련 이슈
- closes #26

## 작업 내용
- 리뷰 좋아요 기능을 구현했습니다

## 변경 사항 
 - POST /api/reviews/{reviewId}/like — 리뷰 좋아요 토글 (추가/취소)
- ReviewLikeResponse DTO 추가 (reviewId, userId, liked)                                                                                                                                                                                  
- ReviewRepository에 increaseLikeCount, decreaseLikeCoun UPDATE 쿼리 추가                                                                                                                                                      
- ReviewLikeRepository에 existsByReviewIdAndUserId, deleteByReviewIdAndUserId 추가                                                                                                                                                                                                                                                                                                                                                                                                                                                                     

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 리뷰 좋아요 토글 기능 추가 — 사용자가 리뷰에 대해 좋아요/해제를 할 수 있고, 좋아요 상태와 카운트가 즉시 반영됩니다.
  * 좋아요 관련 API가 공개되어 클라이언트에서 상태를 확인/조작할 수 있습니다.

* **테스트**
  * 컨트롤러·서비스·레포지토리 단위 테스트 추가로 좋아요 토글, 카운트 증감 및 삭제 동작을 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->