### PR TITLE
feat: 사용자 컨트롤러 구현

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다"),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다"),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 올바르지 않습니다"),
+    USER_FORBIDDEN(HttpStatus.FORBIDDEN, "로그인한 사용자 본인만 접근할 수 있습니다"),
 
     // Review
     INVALID_RATING(HttpStatus.BAD_REQUEST, "평점은 1~5 사이여야 합니다"),

--- a/src/main/java/com/codeit/team4/deokhugam/user/controller/UserController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/controller/UserController.java
@@ -1,8 +1,12 @@
 package com.codeit.team4.deokhugam.user.controller;
 
+import com.codeit.team4.deokhugam.global.annotation.LoginUser;
+import com.codeit.team4.deokhugam.global.dto.DeokhugamUser;
 import com.codeit.team4.deokhugam.user.controller.api.UserApi;
 import com.codeit.team4.deokhugam.user.dto.*;
 import com.codeit.team4.deokhugam.user.service.UserService;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -55,10 +59,10 @@ public class UserController implements UserApi {
     @PatchMapping("/{userId}")
     public ResponseEntity<UserResponse> updateUser(
             @PathVariable UUID userId,
-            @RequestHeader("Deokhugam-Request-User-ID") UUID loginUserId,
+            @LoginUser DeokhugamUser loginUser,
             @Valid @RequestBody UserUpdateRequest request
     ) {
-        log.info("유저 수정 요청: targetUserId={}, loginUserId={}", userId, loginUserId);
+        log.info("유저 수정 요청: targetUserId={}, loginUserId={}", userId, loginUser.userId());
 
         UserResponse response = userService.updateUser(userId, request);
 
@@ -68,9 +72,9 @@ public class UserController implements UserApi {
     @DeleteMapping("/{userId}")
     public ResponseEntity<Void> deleteUser(
             @PathVariable UUID userId,
-            @RequestHeader("Deokhugam-Request-User-ID") UUID loginUserId
+            @LoginUser DeokhugamUser loginUser
     ) {
-        log.info("유저 논리 삭제 요청: targetUserId={}, loginUserId={}", userId, loginUserId);
+        log.info("유저 논리 삭제 요청: targetUserId={}, loginUserId={}", userId, loginUser.userId());
 
         userService.deleteUser(userId);
 
@@ -80,9 +84,9 @@ public class UserController implements UserApi {
     @DeleteMapping("/{userId}/hard")
     public ResponseEntity<Void> hardDeleteUser(
             @PathVariable UUID userId,
-            @RequestHeader("Deokhugam-Request-User-ID") UUID loginUserId
+            @LoginUser DeokhugamUser loginUser
     ) {
-        log.info("유저 물리 삭제 요청: targetUserId={}, loginUserId={}", userId, loginUserId);
+        log.info("유저 물리 삭제 요청: targetUserId={}, loginUserId={}", userId, loginUser.userId());
 
         userService.deleteExpiredUsers();
 

--- a/src/main/java/com/codeit/team4/deokhugam/user/controller/UserController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/controller/UserController.java
@@ -25,7 +25,7 @@ public class UserController implements UserApi {
     public ResponseEntity<UserResponse> register(
             @Valid @RequestBody UserRegisterRequest request
     ) {
-        log.info("회원가입 요청: email={}", request.email());
+        log.info("회원가입 요청");
 
         UserResponse response = userService.registerUser(request);
 
@@ -36,7 +36,7 @@ public class UserController implements UserApi {
     public ResponseEntity<UserResponse> login(
             @Valid @RequestBody UserLoginRequest request
     ) {
-        log.info("로그인 요청: email={}", request.email());
+        log.info("로그인 요청");
 
         UserResponse response = userService.loginUser(request);
 

--- a/src/main/java/com/codeit/team4/deokhugam/user/controller/UserController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/controller/UserController.java
@@ -5,8 +5,6 @@ import com.codeit.team4.deokhugam.global.dto.DeokhugamUser;
 import com.codeit.team4.deokhugam.user.controller.api.UserApi;
 import com.codeit.team4.deokhugam.user.dto.*;
 import com.codeit.team4.deokhugam.user.service.UserService;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -76,7 +74,7 @@ public class UserController implements UserApi {
     ) {
         log.info("유저 논리 삭제 요청: targetUserId={}, loginUserId={}", userId, loginUser.userId());
 
-        userService.deleteUser(userId, loginUser.userId());
+        userService.softDeleteUser(userId, loginUser.userId());
 
         return ResponseEntity.noContent().build();
     }
@@ -88,7 +86,7 @@ public class UserController implements UserApi {
     ) {
         log.info("유저 물리 삭제 요청: targetUserId={}, loginUserId={}", userId, loginUser.userId());
 
-        userService.deleteExpiredUsers();
+        userService.hardDeleteUser(userId, loginUser.userId());
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/codeit/team4/deokhugam/user/controller/UserController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/controller/UserController.java
@@ -64,7 +64,7 @@ public class UserController implements UserApi {
     ) {
         log.info("유저 수정 요청: targetUserId={}, loginUserId={}", userId, loginUser.userId());
 
-        UserResponse response = userService.updateUser(userId, request);
+        UserResponse response = userService.updateUser(userId, loginUser.userId(), request);
 
         return ResponseEntity.ok(response);
     }
@@ -76,7 +76,7 @@ public class UserController implements UserApi {
     ) {
         log.info("유저 논리 삭제 요청: targetUserId={}, loginUserId={}", userId, loginUser.userId());
 
-        userService.deleteUser(userId);
+        userService.deleteUser(userId, loginUser.userId());
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/codeit/team4/deokhugam/user/controller/UserController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/controller/UserController.java
@@ -92,13 +92,4 @@ public class UserController implements UserApi {
 
         return ResponseEntity.noContent().build();
     }
-
-//    @GetMapping("/power")
-//    public ResponseEntity<PageResponse<UserResponse>> getPowerUsers(
-//            @RequestHeader("Deokhugam-Request-User-ID") UUID loginUserId
-//    ) {
-//        log.info("파워 유저 조회 요청: loginUserId={}", loginUserId);
-//
-//        return ResponseEntity.ok(userService.getPowerUsers());
-//    }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/user/controller/UserController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/controller/UserController.java
@@ -1,0 +1,100 @@
+package com.codeit.team4.deokhugam.user.controller;
+
+import com.codeit.team4.deokhugam.user.controller.api.UserApi;
+import com.codeit.team4.deokhugam.user.dto.*;
+import com.codeit.team4.deokhugam.user.service.UserService;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController implements UserApi {
+
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<UserResponse> register(
+            @Valid @RequestBody UserRegisterRequest request
+    ) {
+        log.info("회원가입 요청: email={}", request.email());
+
+        UserResponse response = userService.registerUser(request);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<UserResponse> login(
+            @Valid @RequestBody UserLoginRequest request
+    ) {
+        log.info("로그인 요청: email={}", request.email());
+
+        UserResponse response = userService.loginUser(request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserResponse> getUser(
+            @PathVariable UUID userId
+    ) {
+        log.info("유저 조회 요청: userId={}", userId);
+
+        UserResponse response = userService.getUser(userId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{userId}")
+    public ResponseEntity<UserResponse> updateUser(
+            @PathVariable UUID userId,
+            @RequestHeader("Deokhugam-Request-User-ID") UUID loginUserId,
+            @Valid @RequestBody UserUpdateRequest request
+    ) {
+        log.info("유저 수정 요청: targetUserId={}, loginUserId={}", userId, loginUserId);
+
+        UserResponse response = userService.updateUser(userId, request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<Void> deleteUser(
+            @PathVariable UUID userId,
+            @RequestHeader("Deokhugam-Request-User-ID") UUID loginUserId
+    ) {
+        log.info("유저 논리 삭제 요청: targetUserId={}, loginUserId={}", userId, loginUserId);
+
+        userService.deleteUser(userId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{userId}/hard")
+    public ResponseEntity<Void> hardDeleteUser(
+            @PathVariable UUID userId,
+            @RequestHeader("Deokhugam-Request-User-ID") UUID loginUserId
+    ) {
+        log.info("유저 물리 삭제 요청: targetUserId={}, loginUserId={}", userId, loginUserId);
+
+        userService.deleteExpiredUsers();
+
+        return ResponseEntity.noContent().build();
+    }
+
+//    @GetMapping("/power")
+//    public ResponseEntity<PageResponse<UserResponse>> getPowerUsers(
+//            @RequestHeader("Deokhugam-Request-User-ID") UUID loginUserId
+//    ) {
+//        log.info("파워 유저 조회 요청: loginUserId={}", loginUserId);
+//
+//        return ResponseEntity.ok(userService.getPowerUsers());
+//    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/user/controller/api/UserApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/controller/api/UserApi.java
@@ -43,6 +43,8 @@ public interface UserApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "401", description = "로그인 실패 (이메일 또는 비밀번호 불일치)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "사용자 정보 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
@@ -60,6 +62,7 @@ public interface UserApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<UserResponse> getUser(
+            @Parameter(description = "조회 대상 사용자 ID", required = true)
             @PathVariable UUID userId
     );
 
@@ -78,6 +81,7 @@ public interface UserApi {
     })
     @Parameter(name = "Deokhugam-Request-User-ID", in = ParameterIn.HEADER, required = true)
     ResponseEntity<UserResponse> updateUser(
+            @Parameter(description = "수정 대상 사용자 ID", required = true)
             @PathVariable UUID userId,
             @LoginUser DeokhugamUser loginUser,
             @Valid @RequestBody UserUpdateRequest request
@@ -95,6 +99,7 @@ public interface UserApi {
     })
     @Parameter(name = "Deokhugam-Request-User-ID", in = ParameterIn.HEADER, required = true)
     ResponseEntity<Void> deleteUser(
+            @Parameter(description = "논리 삭제 대상 사용자 ID", required = true)
             @PathVariable UUID userId,
             @LoginUser DeokhugamUser loginUser
     );
@@ -111,6 +116,7 @@ public interface UserApi {
     })
     @Parameter(name = "Deokhugam-Request-User-ID", in = ParameterIn.HEADER, required = true)
     ResponseEntity<Void> hardDeleteUser(
+            @Parameter(description = "물리 삭제 대상 사용자 ID", required = true)
             @PathVariable UUID userId,
             @LoginUser DeokhugamUser loginUser
     );

--- a/src/main/java/com/codeit/team4/deokhugam/user/controller/api/UserApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/controller/api/UserApi.java
@@ -1,5 +1,7 @@
 package com.codeit.team4.deokhugam.user.controller.api;
 
+import com.codeit.team4.deokhugam.global.annotation.LoginUser;
+import com.codeit.team4.deokhugam.global.dto.DeokhugamUser;
 import com.codeit.team4.deokhugam.global.error.ErrorResponse;
 import com.codeit.team4.deokhugam.user.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
@@ -77,7 +79,7 @@ public interface UserApi {
     @Parameter(name = "Deokhugam-Request-User-ID", in = ParameterIn.HEADER, required = true)
     ResponseEntity<UserResponse> updateUser(
             @PathVariable UUID userId,
-            @RequestHeader("Deokhugam-Request-User-ID") UUID loginUserId,
+            @LoginUser DeokhugamUser loginUser,
             @Valid @RequestBody UserUpdateRequest request
     );
 
@@ -94,7 +96,7 @@ public interface UserApi {
     @Parameter(name = "Deokhugam-Request-User-ID", in = ParameterIn.HEADER, required = true)
     ResponseEntity<Void> deleteUser(
             @PathVariable UUID userId,
-            @RequestHeader("Deokhugam-Request-User-ID") UUID loginUserId
+            @LoginUser DeokhugamUser loginUser
     );
 
     @Operation(summary = "사용자 물리 삭제", description = "사용자를 완전히 삭제합니다.")
@@ -110,6 +112,6 @@ public interface UserApi {
     @Parameter(name = "Deokhugam-Request-User-ID", in = ParameterIn.HEADER, required = true)
     ResponseEntity<Void> hardDeleteUser(
             @PathVariable UUID userId,
-            @RequestHeader("Deokhugam-Request-User-ID") UUID loginUserId
+            @LoginUser DeokhugamUser loginUser
     );
 }

--- a/src/main/java/com/codeit/team4/deokhugam/user/controller/api/UserApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/controller/api/UserApi.java
@@ -1,0 +1,115 @@
+package com.codeit.team4.deokhugam.user.controller.api;
+
+import com.codeit.team4.deokhugam.global.error.ErrorResponse;
+import com.codeit.team4.deokhugam.user.dto.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "사용자 관리", description = "사용자 관련 API")
+public interface UserApi {
+
+    @Operation(summary = "회원가입", description = "이메일, 닉네임, 비밀번호로 회원가입을 진행합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "회원가입 성공",
+                    content = @Content(schema = @Schema(implementation = UserResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "409", description = "이메일 중복",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<UserResponse> register(
+            @Valid @RequestBody UserRegisterRequest request
+    );
+
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = UserResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "로그인 실패 (이메일 또는 비밀번호 불일치)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<UserResponse> login(
+            @Valid @RequestBody UserLoginRequest request
+    );
+
+    @Operation(summary = "사용자 정보 조회", description = "사용자 ID로 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용자 정보 조회 성공",
+                    content = @Content(schema = @Schema(implementation = UserResponse.class))),
+            @ApiResponse(responseCode = "404", description = "사용자 정보 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<UserResponse> getUser(
+            @PathVariable UUID userId
+    );
+
+    @Operation(summary = "사용자 정보 수정", description = "사용자의 닉네임을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용자 정보 수정 성공",
+                    content = @Content(schema = @Schema(implementation = UserResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (입력값 검증 실패)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "사용자 정보 수정 권한 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "사용자 정보 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @Parameter(name = "Deokhugam-Request-User-ID", in = ParameterIn.HEADER, required = true)
+    ResponseEntity<UserResponse> updateUser(
+            @PathVariable UUID userId,
+            @RequestHeader("Deokhugam-Request-User-ID") UUID loginUserId,
+            @Valid @RequestBody UserUpdateRequest request
+    );
+
+    @Operation(summary = "사용자 논리 삭제", description = "사용자를 논리적으로 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "사용자 삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "사용자 삭제 권한 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "사용자 정보 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @Parameter(name = "Deokhugam-Request-User-ID", in = ParameterIn.HEADER, required = true)
+    ResponseEntity<Void> deleteUser(
+            @PathVariable UUID userId,
+            @RequestHeader("Deokhugam-Request-User-ID") UUID loginUserId
+    );
+
+    @Operation(summary = "사용자 물리 삭제", description = "사용자를 완전히 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "사용자 삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "사용자 삭제 권한 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "사용자 정보 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @Parameter(name = "Deokhugam-Request-User-ID", in = ParameterIn.HEADER, required = true)
+    ResponseEntity<Void> hardDeleteUser(
+            @PathVariable UUID userId,
+            @RequestHeader("Deokhugam-Request-User-ID") UUID loginUserId
+    );
+}

--- a/src/main/java/com/codeit/team4/deokhugam/user/mapper/UserMapper.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/mapper/UserMapper.java
@@ -1,15 +1,11 @@
 package com.codeit.team4.deokhugam.user.mapper;
 
-import com.codeit.team4.deokhugam.user.dto.UserRegisterRequest;
 import com.codeit.team4.deokhugam.user.dto.UserResponse;
 import com.codeit.team4.deokhugam.user.entity.User;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {
-
-    User toEntity(UserRegisterRequest request);
 
     UserResponse toResponse(User user);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/user/mapper/UserMapper.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/mapper/UserMapper.java
@@ -4,6 +4,7 @@ import com.codeit.team4.deokhugam.user.dto.UserRegisterRequest;
 import com.codeit.team4.deokhugam.user.dto.UserResponse;
 import com.codeit.team4.deokhugam.user.entity.User;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {

--- a/src/main/java/com/codeit/team4/deokhugam/user/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/scheduler/UserCleanupScheduler.java
@@ -17,7 +17,7 @@ public class UserCleanupScheduler {
     public void runCleanup() {
         log.info("유저 물리 삭제 스케줄러 시작");
         try {
-            userService.deleteExpiredUsers();
+            userService.deleteExpiredSoftDeletedUsers();
             log.info("유저 물리 삭제 스케줄러 완료");
         } catch (Exception e) {
             log.error("유저 물리 삭제 스케줄러 실패", e);

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
@@ -9,6 +9,8 @@ import java.util.UUID;
 
 public interface UserService {
 
+    UserResponse getUser(UUID userId);
+
     UserResponse registerUser(UserRegisterRequest request);
 
     UserResponse loginUser(UserLoginRequest request);

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
@@ -17,9 +17,9 @@ public interface UserService {
 
     User findById(UUID userId);
 
-    UserResponse updateUser(UUID userId, UserUpdateRequest request);
+    UserResponse updateUser(UUID userId, UUID loginUserId, UserUpdateRequest request);
 
-    void deleteUser(UUID userId);
+    void deleteUser(UUID userId, UUID loginUserId);
 
     void deleteExpiredUsers();
 }

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
@@ -19,7 +19,9 @@ public interface UserService {
 
     UserResponse updateUser(UUID userId, UUID loginUserId, UserUpdateRequest request);
 
-    void deleteUser(UUID userId, UUID loginUserId);
+    void softDeleteUser(UUID userId, UUID loginUserId);
 
-    void deleteExpiredUsers();
+    void hardDeleteUser(UUID userId, UUID loginUserId);
+
+    void deleteExpiredSoftDeletedUsers();
 }

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
@@ -31,13 +31,21 @@ public class UserServiceImpl implements UserService {
     private final UserMapper userMapper;
 
     @Override
+    public UserResponse getUser(UUID userId) {
+
+        User user = findById(userId);
+
+        return userMapper.toResponse(user);
+    }
+
+    @Override
     @Transactional
     public UserResponse registerUser(UserRegisterRequest request) {
 
         validateEmailNotExists(request.email());
 
         try {
-            User user = userMapper.toEntity(request);
+            User user = new User(request.email(), request.nickname(), request.password());
             User savedUser = userRepository.save(user);
 
             log.info("회원가입 성공: userId={}", savedUser.getId());

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
@@ -91,6 +91,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional
     public void softDeleteUser(UUID userId, UUID loginUserId) {
 
         User user = findById(userId);
@@ -139,7 +140,10 @@ public class UserServiceImpl implements UserService {
 
     private void validateOwner(UUID targetUserId, UUID loginUserId) {
         if (!Objects.equals(targetUserId, loginUserId)) {
-            throw new BusinessException(ErrorCode.USER_FORBIDDEN);
+            throw new BusinessException(
+                    ErrorCode.USER_FORBIDDEN,
+                    "targetUserId=" + targetUserId + ", loginUserId=" + loginUserId
+            );
         }
     }
 

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
@@ -78,9 +78,10 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public UserResponse updateUser(UUID userId, UserUpdateRequest request) {
+    public UserResponse updateUser(UUID userId, UUID loginUserId, UserUpdateRequest request) {
 
         User user = findById(userId);
+        validateOwner(userId, loginUserId);
 
         user.updateNickname(request.nickname());
 
@@ -90,14 +91,14 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    @Transactional
-    public void deleteUser(UUID userId) {
+    public void deleteUser(UUID userId, UUID loginUserId) {
 
         User user = findById(userId);
+        validateOwner(userId, loginUserId);
 
         user.softDelete();
 
-        log.info("유저 삭제 완료: userId={}", userId);
+        log.info("유저 삭제 완료: userId={}, loginUserId={}", userId, loginUserId);
     }
 
     @Override
@@ -121,6 +122,12 @@ public class UserServiceImpl implements UserService {
     private void validatePassword(User user, String password) {
         if (!Objects.equals(user.getPassword(), password)) {
             throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+    }
+
+    private void validateOwner(UUID targetUserId, UUID loginUserId) {
+        if (!Objects.equals(targetUserId, loginUserId)) {
+            throw new BusinessException(ErrorCode.USER_FORBIDDEN);
         }
     }
 

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
@@ -91,7 +91,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void deleteUser(UUID userId, UUID loginUserId) {
+    public void softDeleteUser(UUID userId, UUID loginUserId) {
 
         User user = findById(userId);
         validateOwner(userId, loginUserId);
@@ -103,7 +103,19 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public void deleteExpiredUsers() {
+    public void hardDeleteUser(UUID userId, UUID loginUserId) {
+
+        User user = findById(userId);
+        validateOwner(userId, loginUserId);
+
+        userRepository.delete(user);
+
+        log.info("유저 물리 삭제 완료: userId={}", userId);
+    }
+
+    @Override
+    @Transactional
+    public void deleteExpiredSoftDeletedUsers() {
 
         Instant threshold = Instant.now().minus(1, ChronoUnit.DAYS);
 

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserServiceImpl.java
@@ -111,7 +111,7 @@ public class UserServiceImpl implements UserService {
 
         userRepository.delete(user);
 
-        log.info("유저 물리 삭제 완료: userId={}", userId);
+        log.info("유저 단건 물리 삭제 완료: userId={}, loginUserId={}", userId, loginUserId);
     }
 
     @Override

--- a/src/test/java/com/codeit/team4/deokhugam/user/controller/UserControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/controller/UserControllerTest.java
@@ -1,0 +1,406 @@
+package com.codeit.team4.deokhugam.user.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.codeit.team4.deokhugam.global.config.AppProperties;
+import com.codeit.team4.deokhugam.global.error.BusinessException;
+import com.codeit.team4.deokhugam.global.error.ErrorCode;
+import com.codeit.team4.deokhugam.user.dto.UserResponse;
+import com.codeit.team4.deokhugam.user.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(UserController.class)
+@Import(AppProperties.class)
+@ActiveProfiles("test")
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private UserService userService;
+
+    private static final String USER_ID_HEADER = "Deokhugam-Request-User-ID";
+
+    @Test
+    @DisplayName("회원가입 성공")
+    void register_success() throws Exception {
+
+        // given
+        UserResponse response = new UserResponse(
+                UUID.randomUUID(),
+                "test@test.com",
+                "user1",
+                Instant.now()
+        );
+
+        given(userService.registerUser(any())).willReturn(response);
+
+        var request = java.util.Map.of(
+                "email", "test@test.com",
+                "nickname", "user1",
+                "password", "password1!"
+        );
+
+        // when
+        var result = mockMvc.perform(post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.email").value("test@test.com"))
+                .andExpect(jsonPath("$.createdAt").exists());
+    }
+
+    @Test
+    @DisplayName("이메일이 중복 되어서 회원가입 실패")
+    void register_fail_duplicateEmail() throws Exception {
+
+        // given
+        given(userService.registerUser(any()))
+                .willThrow(new BusinessException(ErrorCode.DUPLICATE_EMAIL));
+
+        var request = java.util.Map.of(
+                "email", "test@test.com",
+                "nickname", "user1",
+                "password", "password1!"
+        );
+
+        // when
+        var result = mockMvc.perform(post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isConflict())
+                .andExpect(jsonPath("$.errorCode").value("DUPLICATE_EMAIL"));
+    }
+
+    @Test
+    @DisplayName("이메일 형식 올바르지 않아서 회원가입 실패")
+    void register_fail_invalidEmail() throws Exception {
+
+        // given
+        var request = java.util.Map.of(
+                "email", "invalid-email",
+                "nickname", "user1",
+                "password", "password1!"
+        );
+
+        // when
+        var result = mockMvc.perform(post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("필수값 누락으로 회원가입 실패")
+    void register_fail_missingField() throws Exception {
+
+        // given
+        var request = java.util.Map.of(
+                "email", "",
+                "nickname", "user1",
+                "password", "password1!"
+        );
+
+        // when
+        var result = mockMvc.perform(post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    void login_success() throws Exception {
+
+        // given
+        UserResponse response = new UserResponse(
+                UUID.randomUUID(),
+                "test@test.com",
+                "user1",
+                Instant.now()
+        );
+
+        given(userService.loginUser(any())).willReturn(response);
+
+        var request = java.util.Map.of(
+                "email", "test@test.com",
+                "password", "password1!"
+        );
+
+        // when
+        var result = mockMvc.perform(post("/api/users/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("test@test.com"));
+    }
+
+    @Test
+    @DisplayName("비밀번호가 올바르지 않아서 로그인 실패")
+    void login_fail_wrongPassword() throws Exception {
+
+        // given
+        given(userService.loginUser(any()))
+                .willThrow(new BusinessException(ErrorCode.INVALID_PASSWORD));
+
+        var request = java.util.Map.of(
+                "email", "test@test.com",
+                "password", "wrong"
+        );
+
+        // when
+        var result = mockMvc.perform(post("/api/users/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.errorCode").value("INVALID_PASSWORD"));
+    }
+
+    @Test
+    @DisplayName("사용자가 존재하지 않아서 로그인 실패")
+    void login_fail_userNotFound() throws Exception {
+
+        // given
+        given(userService.loginUser(any()))
+                .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        var request = java.util.Map.of(
+                "email", "test@test.com",
+                "password", "wrong"
+        );
+
+        // when
+        var result = mockMvc.perform(post("/api/users/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.errorCode").value("USER_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("사용자 정보 수정 성공")
+    void updateUser_success() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID loginUserId = UUID.randomUUID();
+
+        UserResponse response = new UserResponse(
+                userId,
+                "test@test.com",
+                "newNickname",
+                Instant.now()
+        );
+
+        given(userService.updateUser(eq(userId), any()))
+                .willReturn(response);
+
+        var request = java.util.Map.of(
+                "nickname", "newNickname"
+        );
+
+        // when
+        var result = mockMvc.perform(patch("/api/users/{userId}", userId)
+                .header(USER_ID_HEADER, loginUserId.toString())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(userId.toString()))
+                .andExpect(jsonPath("$.email").value("test@test.com"))
+                .andExpect(jsonPath("$.nickname").value("newNickname"));
+    }
+
+    @Test
+    @DisplayName("헤더 누락 시 사용자 수정 실패")
+    void updateUser_missingHeader_fail() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+
+        var request = java.util.Map.of(
+                "nickname", "newNickname"
+        );
+
+        // when
+        var result = mockMvc.perform(patch("/api/users/{userId}", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 수정 실패")
+    void updateUser_notFound_fail() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID loginUserId = UUID.randomUUID();
+
+        given(userService.updateUser(eq(userId), any()))
+                .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        var request = java.util.Map.of(
+                "nickname", "newNickname"
+        );
+
+        // when
+        var result = mockMvc.perform(patch("/api/users/{userId}", userId)
+                .header(USER_ID_HEADER, loginUserId.toString())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("USER_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("사용자 논리 삭제 성공")
+    void deleteUser_success() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID loginUserId = UUID.randomUUID();
+
+        doNothing().when(userService).deleteUser(userId);
+
+        // when
+        var result = mockMvc.perform(delete("/api/users/{userId}", userId)
+                .header(USER_ID_HEADER, loginUserId.toString()));
+
+        // then
+        result.andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("헤더 누락 시 사용자 삭제 실패")
+    void deleteUser_missingHeader_fail() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+
+        // when
+        var result = mockMvc.perform(delete("/api/users/{userId}", userId));
+
+        // then
+        result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("MISSING_HEADER"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 삭제 실패")
+    void deleteUser_notFound_fail() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID loginUserId = UUID.randomUUID();
+
+        doThrow(new BusinessException(ErrorCode.USER_NOT_FOUND))
+                .when(userService).deleteUser(userId);
+
+        // when
+        var result = mockMvc.perform(delete("/api/users/{userId}", userId)
+                .header(USER_ID_HEADER, loginUserId.toString()));
+
+        // then
+        result.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("USER_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("사용자 물리 삭제 성공")
+    void hardDeleteUser_success() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID loginUserId = UUID.randomUUID();
+
+        doNothing().when(userService).deleteExpiredUsers();
+
+        // when
+        var result = mockMvc.perform(delete("/api/users/{userId}/hard", userId)
+                .header(USER_ID_HEADER, loginUserId.toString()));
+
+        // then
+        result.andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("헤더 누락 시 사용자 물리 삭제 실패")
+    void hardDeleteUser_missingHeader_fail() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+
+        // when
+        var result = mockMvc.perform(delete("/api/users/{userId}/hard", userId));
+
+        // then
+        result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("MISSING_HEADER"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 물리 삭제 실패")
+    void hardDeleteUser_notFound_fail() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID loginUserId = UUID.randomUUID();
+
+        doThrow(new BusinessException(ErrorCode.USER_NOT_FOUND))
+                .when(userService).deleteExpiredUsers();
+
+        // when
+        var result = mockMvc.perform(delete("/api/users/{userId}/hard", userId)
+                .header(USER_ID_HEADER, loginUserId.toString()));
+
+        // then
+        result.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("USER_NOT_FOUND"));
+    }
+}

--- a/src/test/java/com/codeit/team4/deokhugam/user/controller/UserControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/controller/UserControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -122,8 +123,27 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("필수값 누락으로 회원가입 실패")
-    void register_fail_missingField() throws Exception {
+    @DisplayName("이메일 필드 누락으로 회원가입 실패")
+    void register_fail_missing_email_field() throws Exception {
+
+        // given
+        var request = java.util.Map.of(
+                "nickname", "user1",
+                "password", "password1!"
+        );
+
+        // when
+        var result = mockMvc.perform(post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("이메일 빈 값으로 회원가입 실패")
+    void register_fail_blank_email() throws Exception {
 
         // given
         var request = java.util.Map.of(
@@ -218,6 +238,54 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("사용자 단건 조회 성공")
+    void getUser_success() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+
+        UserResponse response = new UserResponse(
+                userId,
+                "test@test.com",
+                "user1",
+                Instant.now()
+        );
+
+        given(userService.getUser(userId))
+                .willReturn(response);
+
+        // when
+        var result = mockMvc.perform(get("/api/users/{userId}", userId)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(userId.toString()))
+                .andExpect(jsonPath("$.email").value("test@test.com"))
+                .andExpect(jsonPath("$.nickname").value("user1"))
+                .andExpect(jsonPath("$.createdAt").exists());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 조회 실패")
+    void getUser_notFound_fail() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+
+        given(userService.getUser(userId))
+                .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // when
+        var result = mockMvc.perform(get("/api/users/{userId}", userId)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("USER_NOT_FOUND"));
+    }
+
+    @Test
     @DisplayName("사용자 정보 수정 성공")
     void updateUser_success() throws Exception {
 
@@ -299,6 +367,32 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("본인 확인 실패로 사용자 수정 실패")
+    void updateUser_forbidden_fail() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID loginUserId = UUID.randomUUID();
+
+        given(userService.updateUser(eq(userId), eq(loginUserId), any()))
+                .willThrow(new BusinessException(ErrorCode.USER_FORBIDDEN));
+
+        var request = java.util.Map.of(
+                "nickname", "newNickname"
+        );
+
+        // when
+        var result = mockMvc.perform(patch("/api/users/{userId}", userId)
+                .header(USER_ID_HEADER, loginUserId.toString())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value("USER_FORBIDDEN"));
+    }
+
+    @Test
     @DisplayName("사용자 논리 삭제 성공")
     void softDeleteUser_success() throws Exception {
 
@@ -317,7 +411,7 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("헤더 누락 시 사용자 삭제 실패")
+    @DisplayName("헤더 누락 시 사용자 논리 삭제 실패")
     void softDeleteUser_missingHeader_fail() throws Exception {
 
         // given
@@ -332,7 +426,7 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 사용자 삭제 실패")
+    @DisplayName("존재하지 않는 사용자 논리 삭제 실패")
     void softDeleteUser_notFound_fail() throws Exception {
 
         // given
@@ -349,6 +443,26 @@ class UserControllerTest {
         // then
         result.andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.errorCode").value("USER_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("본인 확인 실패로 사용자 논리 삭제 실패 (403)")
+    void softDeleteUser_forbidden_fail() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID loginUserId = UUID.randomUUID();
+
+        doThrow(new BusinessException(ErrorCode.USER_FORBIDDEN))
+                .when(userService).softDeleteUser(eq(userId), eq(loginUserId));
+
+        // when
+        var result = mockMvc.perform(delete("/api/users/{userId}", userId)
+                .header(USER_ID_HEADER, loginUserId.toString()));
+
+        // then
+        result.andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value("USER_FORBIDDEN"));
     }
 
     @Test
@@ -402,5 +516,25 @@ class UserControllerTest {
         // then
         result.andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.errorCode").value("USER_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("본인 확인 실패로 사용자 물리 삭제 실패")
+    void hardDeleteUser_forbidden_fail() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID loginUserId = UUID.randomUUID();
+
+        doThrow(new BusinessException(ErrorCode.USER_FORBIDDEN))
+                .when(userService).hardDeleteUser(eq(userId), eq(loginUserId));
+
+        // when
+        var result = mockMvc.perform(delete("/api/users/{userId}/hard", userId)
+                .header(USER_ID_HEADER, loginUserId.toString()));
+
+        // then
+        result.andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value("USER_FORBIDDEN"));
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/user/controller/UserControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/controller/UserControllerTest.java
@@ -232,7 +232,7 @@ class UserControllerTest {
                 Instant.now()
         );
 
-        given(userService.updateUser(eq(userId), any()))
+        given(userService.updateUser(eq(userId), eq(loginUserId), any()))
                 .willReturn(response);
 
         var request = java.util.Map.of(
@@ -280,7 +280,7 @@ class UserControllerTest {
         UUID userId = UUID.randomUUID();
         UUID loginUserId = UUID.randomUUID();
 
-        given(userService.updateUser(eq(userId), any()))
+        given(userService.updateUser(eq(userId), eq(loginUserId), any()))
                 .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         var request = java.util.Map.of(
@@ -306,7 +306,7 @@ class UserControllerTest {
         UUID userId = UUID.randomUUID();
         UUID loginUserId = UUID.randomUUID();
 
-        doNothing().when(userService).deleteUser(userId);
+        doNothing().when(userService).deleteUser(eq(userId), eq(loginUserId));
 
         // when
         var result = mockMvc.perform(delete("/api/users/{userId}", userId)
@@ -340,7 +340,7 @@ class UserControllerTest {
         UUID loginUserId = UUID.randomUUID();
 
         doThrow(new BusinessException(ErrorCode.USER_NOT_FOUND))
-                .when(userService).deleteUser(userId);
+                .when(userService).deleteUser(eq(userId), eq(loginUserId));
 
         // when
         var result = mockMvc.perform(delete("/api/users/{userId}", userId)

--- a/src/test/java/com/codeit/team4/deokhugam/user/controller/UserControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/controller/UserControllerTest.java
@@ -291,7 +291,7 @@ class UserControllerTest {
 
         // given
         UUID userId = UUID.randomUUID();
-        UUID loginUserId = UUID.randomUUID();
+        UUID loginUserId = userId;
 
         UserResponse response = new UserResponse(
                 userId,
@@ -398,7 +398,7 @@ class UserControllerTest {
 
         // given
         UUID userId = UUID.randomUUID();
-        UUID loginUserId = UUID.randomUUID();
+        UUID loginUserId = userId;
 
         doNothing().when(userService).softDeleteUser(eq(userId), eq(loginUserId));
 
@@ -471,7 +471,7 @@ class UserControllerTest {
 
         // given
         UUID userId = UUID.randomUUID();
-        UUID loginUserId = UUID.randomUUID();
+        UUID loginUserId = userId;
 
         doNothing().when(userService).hardDeleteUser(eq(userId), eq(loginUserId));
 

--- a/src/test/java/com/codeit/team4/deokhugam/user/controller/UserControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/controller/UserControllerTest.java
@@ -300,13 +300,13 @@ class UserControllerTest {
 
     @Test
     @DisplayName("사용자 논리 삭제 성공")
-    void deleteUser_success() throws Exception {
+    void softDeleteUser_success() throws Exception {
 
         // given
         UUID userId = UUID.randomUUID();
         UUID loginUserId = UUID.randomUUID();
 
-        doNothing().when(userService).deleteUser(eq(userId), eq(loginUserId));
+        doNothing().when(userService).softDeleteUser(eq(userId), eq(loginUserId));
 
         // when
         var result = mockMvc.perform(delete("/api/users/{userId}", userId)
@@ -318,7 +318,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("헤더 누락 시 사용자 삭제 실패")
-    void deleteUser_missingHeader_fail() throws Exception {
+    void softDeleteUser_missingHeader_fail() throws Exception {
 
         // given
         UUID userId = UUID.randomUUID();
@@ -333,14 +333,14 @@ class UserControllerTest {
 
     @Test
     @DisplayName("존재하지 않는 사용자 삭제 실패")
-    void deleteUser_notFound_fail() throws Exception {
+    void softDeleteUser_notFound_fail() throws Exception {
 
         // given
         UUID userId = UUID.randomUUID();
         UUID loginUserId = UUID.randomUUID();
 
         doThrow(new BusinessException(ErrorCode.USER_NOT_FOUND))
-                .when(userService).deleteUser(eq(userId), eq(loginUserId));
+                .when(userService).softDeleteUser(eq(userId), eq(loginUserId));
 
         // when
         var result = mockMvc.perform(delete("/api/users/{userId}", userId)
@@ -352,14 +352,14 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("사용자 물리 삭제 성공")
+    @DisplayName("단건 물리 삭제 성공")
     void hardDeleteUser_success() throws Exception {
 
         // given
         UUID userId = UUID.randomUUID();
         UUID loginUserId = UUID.randomUUID();
 
-        doNothing().when(userService).deleteExpiredUsers();
+        doNothing().when(userService).hardDeleteUser(eq(userId), eq(loginUserId));
 
         // when
         var result = mockMvc.perform(delete("/api/users/{userId}/hard", userId)
@@ -393,7 +393,7 @@ class UserControllerTest {
         UUID loginUserId = UUID.randomUUID();
 
         doThrow(new BusinessException(ErrorCode.USER_NOT_FOUND))
-                .when(userService).deleteExpiredUsers();
+                .when(userService).hardDeleteUser(eq(userId), eq(loginUserId));
 
         // when
         var result = mockMvc.perform(delete("/api/users/{userId}/hard", userId)

--- a/src/test/java/com/codeit/team4/deokhugam/user/controller/UserControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/controller/UserControllerTest.java
@@ -337,7 +337,8 @@ class UserControllerTest {
                 .content(objectMapper.writeValueAsString(request)));
 
         // then
-        result.andExpect(status().isBadRequest());
+        result.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("MISSING_HEADER"));
     }
 
     @Test

--- a/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
@@ -56,7 +56,6 @@ class UserServiceImplTest {
                 "user1",
                 "password1!"
         );
-        User user = new User("test@test.com", "user1", "password1!");
         User savedUser = new User("test@test.com", "user1", "password1!");
 
         when(userRepository.existsByEmailAndDeletedAtIsNull(request.email()))
@@ -271,8 +270,8 @@ class UserServiceImplTest {
     }
 
     @Test
-    @DisplayName("유저 삭제 성공")
-    void deleteUser_success() {
+    @DisplayName("유저 논리 삭제 성공")
+    void softDeleteUser_success() {
         // given
         UUID userId = UUID.randomUUID();
         UUID loginUserId = userId;
@@ -283,7 +282,7 @@ class UserServiceImplTest {
                 .thenReturn(Optional.of(user));
 
         // when
-        userService.deleteUser(userId, loginUserId);
+        userService.softDeleteUser(userId, loginUserId);
 
         // then
         assertThat(user.isDeleted()).isTrue();
@@ -292,8 +291,8 @@ class UserServiceImplTest {
     }
 
     @Test
-    @DisplayName("유저가 존재하지 않아 삭제 실패")
-    void deleteUser_fail_user_not_found() {
+    @DisplayName("유저가 존재하지 않아 논리 삭제 실패")
+    void softDeleteUser_fail_user_not_found() {
         // given
         UUID userId = UUID.randomUUID();
         UUID loginUserId = UUID.randomUUID();
@@ -302,7 +301,7 @@ class UserServiceImplTest {
                 .thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> userService.deleteUser(userId, loginUserId))
+        assertThatThrownBy(() -> userService.softDeleteUser(userId, loginUserId))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.USER_NOT_FOUND);
@@ -311,10 +310,64 @@ class UserServiceImplTest {
     }
 
     @Test
-    @DisplayName("삭제 대상 사용자 물리 삭제 성공")
-    void deleteExpiredUsers_success() {
+    @DisplayName("단건 물리 삭제 성공")
+    void hardDeleteUser_success() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID loginUserId = userId;
+
+        User user = new User("test@test.com", "user", "pw");
+
+        when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                .thenReturn(Optional.of(user));
+
         // when
-        userService.deleteExpiredUsers();
+        userService.hardDeleteUser(userId, loginUserId);
+
+        // then
+        verify(userRepository).findByIdAndDeletedAtIsNull(userId);
+        verify(userRepository).delete(user);
+    }
+
+    @Test
+    @DisplayName("유저가 존재하지 않아 물리 삭제 실패")
+    void hardDeleteUser_fail_user_not_found() {
+        UUID userId = UUID.randomUUID();
+        UUID loginUserId = UUID.randomUUID();
+
+        when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                userService.hardDeleteUser(userId, loginUserId)
+        ).isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("권한이 없어서 물리 삭제 실패")
+    void hardDeleteUser_fail_forbidden() {
+        UUID userId = UUID.randomUUID();
+        UUID loginUserId = UUID.randomUUID();
+
+        User user = new User("test@test.com", "user", "pw");
+
+        when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                .thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() ->
+                userService.hardDeleteUser(userId, loginUserId)
+        ).isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("삭제 대상 사용자 배치 물리 삭제 성공")
+    void deleteExpiredSoftDeletedUsers_success() {
+        // when
+        userService.deleteExpiredSoftDeletedUsers();
 
         // then
         ArgumentCaptor<Instant> captor = ArgumentCaptor.forClass(Instant.class);
@@ -330,13 +383,13 @@ class UserServiceImplTest {
     }
 
     @Test
-    @DisplayName("삭제 대상 사용자가 없어도 물리 삭제 성공")
-    void deleteExpiredUsers_no_target_success() {
+    @DisplayName("삭제 대상 사용자가 없어도 배치 물리 삭제 성공")
+    void deleteExpiredSoftDeletedUsers_no_target_success() {
         // given
         when(userJooqRepository.deleteExpiredUsers(any())).thenReturn(0);
 
         // when
-        userService.deleteExpiredUsers();
+        userService.deleteExpiredSoftDeletedUsers();
 
         // then
         verify(userJooqRepository).deleteExpiredUsers(any(Instant.class));
@@ -344,14 +397,14 @@ class UserServiceImplTest {
     }
 
     @Test
-    @DisplayName("JOOQ 저장소 예외 발생 시 물리 삭제 실패")
-    void deleteExpiredUsers_fail_repository_exception() {
+    @DisplayName("JOOQ 저장소 예외 발생 시 배치 물리 삭제 실패")
+    void deleteExpiredSoftDeletedUsers_fail_repository_exception() {
         // given
         doThrow(new RuntimeException("DB error"))
                 .when(userJooqRepository).deleteExpiredUsers(any());
 
         // when & then
-        assertThatThrownBy(() -> userService.deleteExpiredUsers())
+        assertThatThrownBy(() -> userService.deleteExpiredSoftDeletedUsers())
                 .isInstanceOf(RuntimeException.class);
 
         verify(userJooqRepository).deleteExpiredUsers(any());

--- a/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
@@ -98,7 +98,6 @@ class UserServiceImplTest {
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.DUPLICATE_EMAIL);
 
-        verify(userMapper, never()).toEntity(any());
         verify(userRepository, never()).save(any(User.class));
     }
 

--- a/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -22,8 +21,6 @@ import com.codeit.team4.deokhugam.user.repository.UserJooqRepository;
 import com.codeit.team4.deokhugam.user.repository.UserRepository;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -64,8 +61,10 @@ class UserServiceImplTest {
 
         when(userRepository.existsByEmailAndDeletedAtIsNull(request.email()))
                 .thenReturn(false);
-        when(userMapper.toEntity(request)).thenReturn(user);
-        when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+        when(userRepository.save(any(User.class)))
+                .thenReturn(savedUser);
+
         when(userMapper.toResponse(any(User.class)))
                 .thenReturn(new UserResponse(null, "test@test.com", "user1", null));
 
@@ -77,8 +76,7 @@ class UserServiceImplTest {
                 .extracting(UserResponse::email, UserResponse::nickname)
                 .contains(request.email(), request.nickname());
 
-        verify(userMapper).toEntity(request);
-        verify(userRepository).save(user);
+        verify(userRepository).save(any(User.class));
         verify(userMapper).toResponse(savedUser);
     }
 
@@ -115,12 +113,8 @@ class UserServiceImplTest {
                 "password1!"
         );
 
-        User user = mock(User.class);
-
         when(userRepository.existsByEmailAndDeletedAtIsNull(request.email()))
                 .thenReturn(false);
-
-        when(userMapper.toEntity(request)).thenReturn(user);
 
         when(userRepository.save(any(User.class)))
                 .thenThrow(new DataIntegrityViolationException("duplicate"));
@@ -131,8 +125,7 @@ class UserServiceImplTest {
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.DUPLICATE_EMAIL);
 
-        verify(userMapper).toEntity(request);
-        verify(userRepository).save(user);
+        verify(userRepository).save(any(User.class));
     }
 
     @Test
@@ -232,6 +225,8 @@ class UserServiceImplTest {
     void updateUser_success() {
         // given
         UUID userId = UUID.randomUUID();
+        UUID loginUserId = userId;
+
         UserUpdateRequest request = new UserUpdateRequest("newNick");
 
         User user = new User("test@test.com", "oldNick", "password1!");
@@ -243,7 +238,7 @@ class UserServiceImplTest {
                 .thenReturn(new UserResponse(userId, user.getEmail(), "newNick", null));
 
         // when
-        UserResponse result = userService.updateUser(userId, request);
+        UserResponse result = userService.updateUser(userId, loginUserId, request);
 
         // then
         assertThat(user.getNickname()).isEqualTo("newNick");
@@ -258,13 +253,15 @@ class UserServiceImplTest {
     void updateUser_fail_user_not_found() {
         // given
         UUID userId = UUID.randomUUID();
+        UUID loginUserId = UUID.randomUUID();
+
         UserUpdateRequest request = new UserUpdateRequest("newNick");
 
         when(userRepository.findByIdAndDeletedAtIsNull(userId))
                 .thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> userService.updateUser(userId, request))
+        assertThatThrownBy(() -> userService.updateUser(userId, loginUserId, request))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.USER_NOT_FOUND);
@@ -278,13 +275,15 @@ class UserServiceImplTest {
     void deleteUser_success() {
         // given
         UUID userId = UUID.randomUUID();
+        UUID loginUserId = userId;
+
         User user = new User("test@test.com", "user1", "password1!");
 
         when(userRepository.findByIdAndDeletedAtIsNull(userId))
                 .thenReturn(Optional.of(user));
 
         // when
-        userService.deleteUser(userId);
+        userService.deleteUser(userId, loginUserId);
 
         // then
         assertThat(user.isDeleted()).isTrue();
@@ -297,12 +296,13 @@ class UserServiceImplTest {
     void deleteUser_fail_user_not_found() {
         // given
         UUID userId = UUID.randomUUID();
+        UUID loginUserId = UUID.randomUUID();
 
         when(userRepository.findByIdAndDeletedAtIsNull(userId))
                 .thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> userService.deleteUser(userId))
+        assertThatThrownBy(() -> userService.deleteUser(userId, loginUserId))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.USER_NOT_FOUND);


### PR DESCRIPTION
## 관련 이슈
- closes #52 

## 작업 내용
- [x] 회원가입 API 구현 (POST /api/users)
- [x] 로그인 API 구현 (POST /api/users/login)
- [x] 사용자 정보 조회 API 구현 (GET /api/users/{userId})
- [x] 사용자 정보 수정 API 구현 (PATCH /api/users/{userId})
- [x] 사용자 논리 삭제 API 구현 (DELETE /api/users/{userId})
- [x] 사용자 물리 삭제 API 구현 (DELETE /api/users/{userId}/hard)
- [x] 요청 DTO Validation 적용 (`@Valid`)
- [x] 요청 헤더 기반 사용자 식별 처리 (Deokhugam-Request-User-ID)
- [x] 공통 예외 처리 구조 연동
- [x] 테스트 코드 작성 

## 변경 사항
- 사용자 API에서 Deokhugam-Request-User-ID 헤더는 클라이언트 요청에 포함
- LoginUserArgumentResolver에서 해당 헤더를 직접 읽어 사용자 검증 및 주입 처리
- 헤더가 없을 경우 Resolver 단계에서 즉시 예외 처리되도록 구현하여 인증 누락 요청 차단
- 컨트롤러에서는 `@LoginUser` 를 통해 사용자 정보를 주입받는 구조로 통일

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 등록·로그인, 프로필 조회·수정 기능이 추가되었습니다.
  * 사용자 계정 삭제 기능이 추가되었습니다(일반 삭제·영구 삭제 구분).

* **Behavior Changes**
  * 프로필 수정 및 삭제는 본인 인증 헤더 필요—소유자 검증으로 타인 접근이 제한됩니다.
  * 삭제된 계정 정리 작업이 소프트삭제 대상 기준으로 변경되었습니다.

* **Tests**
  * 사용자 관리 전반에 대한 웹 계층 및 단위 테스트가 대폭 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->