### PR TITLE
feat: 댓글 논리 삭제 구현

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/comment/controller/CommentController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/controller/CommentController.java
@@ -58,6 +58,8 @@ public class CommentController implements CommentApi {
             @PathVariable UUID commentId,
             @LoginUser DeokhugamUser loginUser) {
 
+        log.info("댓글 논리 삭제 요청: commentId={}, userId={}", commentId, loginUser.userId());
+
         commentService.softDeleteComment(commentId, loginUser.userId());
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/codeit/team4/deokhugam/comment/controller/CommentController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/controller/CommentController.java
@@ -47,9 +47,10 @@ public class CommentController implements CommentApi {
             @LoginUser DeokhugamUser loginUser,
             @Valid @RequestBody CommentUpdateRequest request) {
 
-        log.info("댓글 수정 요청: commentId={}  userId={}", commentId, loginUser.userId());
+        log.info("댓글 수정 요청: commentId={}, userId={}", commentId, loginUser.userId());
 
-        return ResponseEntity.ok(commentService.updateComment(commentId, loginUser.userId(), request));
+        return ResponseEntity.ok(
+                commentService.updateComment(commentId, loginUser.userId(), request));
     }
 
     @Override

--- a/src/main/java/com/codeit/team4/deokhugam/comment/controller/CommentController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/controller/CommentController.java
@@ -5,6 +5,8 @@ import com.codeit.team4.deokhugam.comment.dto.CommentCreateRequest;
 import com.codeit.team4.deokhugam.comment.dto.CommentResponse;
 import com.codeit.team4.deokhugam.comment.dto.CommentUpdateRequest;
 import com.codeit.team4.deokhugam.comment.service.CommentService;
+import com.codeit.team4.deokhugam.global.annotation.LoginUser;
+import com.codeit.team4.deokhugam.global.dto.DeokhugamUser;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +17,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -42,11 +43,11 @@ public class CommentController implements CommentApi {
     @PatchMapping("/{commentId}")
     public ResponseEntity<CommentResponse> updateComment(
             @PathVariable UUID commentId,
-            @RequestHeader("Deokhugam-Request-User-ID") UUID userId,
+            @LoginUser DeokhugamUser loginUser,
             @Valid @RequestBody CommentUpdateRequest request) {
 
-        log.info("댓글 수정 요청: commentId={}  userId={}", commentId, userId);
+        log.info("댓글 수정 요청: commentId={}  userId={}", commentId, loginUser.userId());
 
-        return ResponseEntity.ok(commentService.updateComment(commentId, userId, request));
+        return ResponseEntity.ok(commentService.updateComment(commentId, loginUser.userId(), request));
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/controller/CommentController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/controller/CommentController.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -49,5 +50,16 @@ public class CommentController implements CommentApi {
         log.info("댓글 수정 요청: commentId={}  userId={}", commentId, loginUser.userId());
 
         return ResponseEntity.ok(commentService.updateComment(commentId, loginUser.userId(), request));
+    }
+
+    @Override
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> softDeleteComment(
+            @PathVariable UUID commentId,
+            @LoginUser DeokhugamUser loginUser) {
+
+        commentService.softDeleteComment(commentId, loginUser.userId());
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/controller/api/CommentApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/controller/api/CommentApi.java
@@ -49,10 +49,17 @@ public interface CommentApi {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
+    @Parameters({
+            @Parameter(
+                    name = "Deokhugam-Request-User-ID",
+                    in = ParameterIn.HEADER,
+                    required = true,
+                    description = "요청자 ID"
+            )
+    })
     ResponseEntity<CommentResponse> updateComment(
             @Parameter(description = "댓글 ID", required = true, example = "123e4567-e89b-12d3-a456-426614174000")
             @PathVariable UUID commentId,
-            @Parameter(description = "요청자 ID", required = true)
             @LoginUser DeokhugamUser loginUser,
             @Parameter(
                     description = "댓글 수정 요청 정보",

--- a/src/main/java/com/codeit/team4/deokhugam/comment/controller/api/CommentApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/controller/api/CommentApi.java
@@ -3,6 +3,8 @@ package com.codeit.team4.deokhugam.comment.controller.api;
 import com.codeit.team4.deokhugam.comment.dto.CommentCreateRequest;
 import com.codeit.team4.deokhugam.comment.dto.CommentResponse;
 import com.codeit.team4.deokhugam.comment.dto.CommentUpdateRequest;
+import com.codeit.team4.deokhugam.global.annotation.LoginUser;
+import com.codeit.team4.deokhugam.global.dto.DeokhugamUser;
 import com.codeit.team4.deokhugam.global.error.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -11,13 +13,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "댓글 관리", description = "댓글 관련 API")
 public interface CommentApi {
@@ -52,12 +51,23 @@ public interface CommentApi {
             @Parameter(description = "댓글 ID", required = true, example = "123e4567-e89b-12d3-a456-426614174000")
             @PathVariable UUID commentId,
             @Parameter(description = "요청자 ID", required = true)
-            @RequestHeader("Deokhugam-Request-User-ID") UUID userId,
+            @LoginUser DeokhugamUser loginUser,
             @Parameter(
                     description = "댓글 수정 요청 정보",
                     required = true,
                     content = @Content(schema = @Schema(implementation = CommentUpdateRequest.class)))
             @RequestBody CommentUpdateRequest request
+    );
+
+    @Operation(summary = "댓글 삭제", description = "댓글 작성자 본인만 댓글을 논리 삭제할 수 있습니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "댓글 삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "댓글 삭제 권한 없음 (작성자 불일치)"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 댓글")
+    })
+    ResponseEntity<Void> deleteComment(
+            @Parameter(description = "삭제할 댓글 ID", required = true) @PathVariable UUID commentId,
+            @Parameter(hidden = true) @LoginUser DeokhugamUser loginUser
     );
 
 }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/controller/api/CommentApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/controller/api/CommentApi.java
@@ -72,7 +72,7 @@ public interface CommentApi {
                     name = "Deokhugam-Request-User-ID",
                     in = ParameterIn.HEADER,
                     required = true,
-                    description = "요청을 보내는 현재 로그인된 유저의 식별자"
+                    description = "요청자 ID"
             )
     })
     ResponseEntity<Void> softDeleteComment(

--- a/src/main/java/com/codeit/team4/deokhugam/comment/controller/api/CommentApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/controller/api/CommentApi.java
@@ -61,11 +61,17 @@ public interface CommentApi {
             @RequestBody CommentUpdateRequest request
     );
 
-    @Operation(summary = "댓글 삭제", description = "댓글 작성자 본인만 댓글을 논리 삭제할 수 있습니다.")
+    @Operation(summary = "댓글 논리 삭제", description = "본인이 작성한 댓글을 논리적으로 삭제합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "댓글 삭제 성공"),
-            @ApiResponse(responseCode = "403", description = "댓글 삭제 권한 없음 (작성자 불일치)"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 댓글")
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (요청자 ID 누락)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "댓글 삭제 권한 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "댓글 정보 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @Parameters({
             @Parameter(
@@ -76,7 +82,7 @@ public interface CommentApi {
             )
     })
     ResponseEntity<Void> softDeleteComment(
-            @Parameter(description = "삭제할 댓글 ID", required = true) @PathVariable UUID commentId,
+            @Parameter(description = "댓글 ID", required = true) @PathVariable UUID commentId,
             @LoginUser DeokhugamUser loginUser
     );
 

--- a/src/main/java/com/codeit/team4/deokhugam/comment/controller/api/CommentApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/controller/api/CommentApi.java
@@ -8,6 +8,8 @@ import com.codeit.team4.deokhugam.global.dto.DeokhugamUser;
 import com.codeit.team4.deokhugam.global.error.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -65,9 +67,17 @@ public interface CommentApi {
             @ApiResponse(responseCode = "403", description = "댓글 삭제 권한 없음 (작성자 불일치)"),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 댓글")
     })
-    ResponseEntity<Void> deleteComment(
+    @Parameters({
+            @Parameter(
+                    name = "Deokhugam-Request-User-ID",
+                    in = ParameterIn.HEADER,
+                    required = true,
+                    description = "요청을 보내는 현재 로그인된 유저의 식별자"
+            )
+    })
+    ResponseEntity<Void> softDeleteComment(
             @Parameter(description = "삭제할 댓글 ID", required = true) @PathVariable UUID commentId,
-            @Parameter(hidden = true) @LoginUser DeokhugamUser loginUser
+            @LoginUser DeokhugamUser loginUser
     );
 
 }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/entity/Comment.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/entity/Comment.java
@@ -27,7 +27,6 @@ import org.hibernate.annotations.SQLRestriction;
                 @Index(name = "idx_comments_deleted_at", columnList = "deleted_at"),
                 @Index(name = "idx_comments_created_at", columnList = "created_at")
         })
-@SQLRestriction("deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseUpdatableEntity {
 

--- a/src/main/java/com/codeit/team4/deokhugam/comment/entity/Comment.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/entity/Comment.java
@@ -56,7 +56,9 @@ public class Comment extends BaseUpdatableEntity {
     }
 
     public void softDelete() {
-        this.deletedAt = Instant.now();
+        if (this.deletedAt == null) {
+            this.deletedAt = Instant.now();
+        }
     }
 
     @Override

--- a/src/main/java/com/codeit/team4/deokhugam/comment/entity/Comment.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/entity/Comment.java
@@ -53,6 +53,10 @@ public class Comment extends BaseUpdatableEntity {
         this.content = newContent;
     }
 
+    public void softDelete() {
+        this.deletedAt = Instant.now();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/com/codeit/team4/deokhugam/comment/entity/Comment.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/entity/Comment.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter

--- a/src/main/java/com/codeit/team4/deokhugam/comment/entity/Comment.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/entity/Comment.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
@@ -26,6 +27,7 @@ import lombok.NoArgsConstructor;
                 @Index(name = "idx_comments_deleted_at", columnList = "deleted_at"),
                 @Index(name = "idx_comments_created_at", columnList = "created_at")
         })
+@SQLRestriction("deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends BaseUpdatableEntity {
 

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
@@ -75,9 +75,15 @@ public class CommentService {
     // ========== Private Methods ==========
 
     private Comment findCommentById(UUID commentId) {
-        return commentRepository.findById(commentId)
+        Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new BusinessException(
                         ErrorCode.COMMENT_NOT_FOUND, "commentId: " + commentId));
+
+        if (comment.getDeletedAt() != null) {
+            throw new BusinessException(ErrorCode.COMMENT_NOT_FOUND, "이미 삭제된 댓글입니다. commentId: " + commentId);
+        }
+
+        return comment;
     }
 
     private void validateCommentOwnership(Comment comment, UUID userId, String action) {

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
@@ -52,7 +52,7 @@ public class CommentService {
     public CommentResponse updateComment(UUID commentId, UUID userId, CommentUpdateRequest request) {
         Comment comment = findCommentById(commentId);
 
-        validateCommentOwnership(comment, userId, "수정");
+        validateCommentOwner(comment, userId, "수정");
 
         comment.updateContent(request.content());
 
@@ -64,7 +64,7 @@ public class CommentService {
     public void softDeleteComment(UUID commentId, UUID userId) {
         Comment comment = findCommentById(commentId);
 
-        validateCommentOwnership(comment, userId, "논리 삭제");
+        validateCommentOwner(comment, userId, "논리 삭제");
 
         comment.softDelete();
         reviewRepository.decreaseCommentCount(comment.getReview().getId());
@@ -86,7 +86,7 @@ public class CommentService {
         return comment;
     }
 
-    private void validateCommentOwnership(Comment comment, UUID userId, String action) {
+    private void validateCommentOwner(Comment comment, UUID userId, String action) {
         if (!comment.getUser().getId().equals(userId)) {
             throw new BusinessException(
                     ErrorCode.COMMENT_NOT_OWNER,

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
@@ -64,5 +64,22 @@ public class CommentService {
         return commentMapper.toResponse(comment);
     }
 
+    @Transactional
+    public void softDeleteComment(UUID commentId, UUID userId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new BusinessException(
+                        ErrorCode.COMMENT_NOT_FOUND, "commentId: " + commentId));
+
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED_COMMENT_ACCESS,
+                    String.format("댓글 삭제 권한 없음 - commentId: %s, 요청자: %s", commentId, userId));
+        }
+
+        comment.softDelete();
+
+        log.info("댓글 논리 삭제 완료: commentId={}, userId={}", commentId, userId);
+    }
+
+
 
 }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
@@ -52,9 +52,7 @@ public class CommentService {
     public CommentResponse updateComment(UUID commentId, UUID userId, CommentUpdateRequest request) {
         Comment comment = findCommentById(commentId);
 
-        if (!comment.getUser().getId().equals(userId)) {
-            throw new BusinessException(ErrorCode.UNAUTHORIZED_COMMENT_ACCESS, "userId: " + userId);
-        }
+        validateCommentOwnership(comment, userId, "수정");
 
         comment.updateContent(request.content());
 
@@ -66,10 +64,7 @@ public class CommentService {
     public void softDeleteComment(UUID commentId, UUID userId) {
         Comment comment = findCommentById(commentId);
 
-        if (!comment.getUser().getId().equals(userId)) {
-            throw new BusinessException(ErrorCode.UNAUTHORIZED_COMMENT_ACCESS,
-                    String.format("댓글 삭제 권한 없음 - commentId: %s, 요청자: %s", commentId, userId));
-        }
+        validateCommentOwnership(comment, userId, "논리 삭제");
 
         comment.softDelete();
         reviewRepository.decreaseCommentCount(comment.getReview().getId());
@@ -85,5 +80,14 @@ public class CommentService {
                         ErrorCode.COMMENT_NOT_FOUND, "commentId: " + commentId));
     }
 
+    private void validateCommentOwnership(Comment comment, UUID userId, String action) {
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new BusinessException(
+                    ErrorCode.UNAUTHORIZED_COMMENT_ACCESS,
+                    String.format("댓글 %s 권한 없음 - commentId: %s, 요청자: %s", action, comment.getId(),
+                            userId)
+            );
+        }
+    }
 
 }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
@@ -72,9 +72,12 @@ public class CommentService {
         }
 
         comment.softDelete();
+        reviewRepository.decreaseCommentCount(comment.getReview().getId());
 
         log.info("댓글 논리 삭제 완료: commentId={}, userId={}", commentId, userId);
     }
+
+    // ========== Private Methods ==========
 
     private Comment findCommentById(UUID commentId) {
         return commentRepository.findById(commentId)

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
@@ -50,9 +50,7 @@ public class CommentService {
 
     @Transactional
     public CommentResponse updateComment(UUID commentId, UUID userId, CommentUpdateRequest request) {
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new BusinessException(
-                        ErrorCode.COMMENT_NOT_FOUND, "commentId: " + commentId));
+        Comment comment = findCommentById(commentId);
 
         if (!comment.getUser().getId().equals(userId)) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED_COMMENT_ACCESS, "userId: " + userId);
@@ -66,9 +64,7 @@ public class CommentService {
 
     @Transactional
     public void softDeleteComment(UUID commentId, UUID userId) {
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new BusinessException(
-                        ErrorCode.COMMENT_NOT_FOUND, "commentId: " + commentId));
+        Comment comment = findCommentById(commentId);
 
         if (!comment.getUser().getId().equals(userId)) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED_COMMENT_ACCESS,
@@ -80,6 +76,11 @@ public class CommentService {
         log.info("댓글 논리 삭제 완료: commentId={}, userId={}", commentId, userId);
     }
 
+    private Comment findCommentById(UUID commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new BusinessException(
+                        ErrorCode.COMMENT_NOT_FOUND, "commentId: " + commentId));
+    }
 
 
 }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
@@ -89,7 +89,7 @@ public class CommentService {
     private void validateCommentOwnership(Comment comment, UUID userId, String action) {
         if (!comment.getUser().getId().equals(userId)) {
             throw new BusinessException(
-                    ErrorCode.UNAUTHORIZED_COMMENT_ACCESS,
+                    ErrorCode.COMMENT_NOT_OWNER,
                     String.format("댓글 %s 권한 없음 - commentId: %s, 요청자: %s", action, comment.getId(),
                             userId)
             );

--- a/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
@@ -33,7 +33,6 @@ public enum ErrorCode {
 
     // Comment
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다"),
-    // TODO: 댓글 수정/삭제 기능 구현에서 사용 예정
     UNAUTHORIZED_COMMENT_ACCESS(HttpStatus.FORBIDDEN, "해당 댓글을 수정/삭제할 권한이 없습니다");
 
     private final HttpStatus status;

--- a/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
@@ -33,7 +33,7 @@ public enum ErrorCode {
 
     // Comment
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다"),
-    UNAUTHORIZED_COMMENT_ACCESS(HttpStatus.FORBIDDEN, "해당 댓글을 수정/삭제할 권한이 없습니다");
+    COMMENT_NOT_OWNER(HttpStatus.FORBIDDEN, "해당 댓글을 수정/삭제할 권한이 없습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/codeit/team4/deokhugam/review/repository/ReviewRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/repository/ReviewRepository.java
@@ -21,6 +21,10 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     void increaseCommentCount(@Param("reviewId") UUID reviewId);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("UPDATE Review r SET r.commentCount = r.commentCount - 1 WHERE r.id = :reviewId AND r.commentCount > 0")
+    void decreaseCommentCount(@Param("reviewId") UUID reviewId);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Review r SET r.likeCount = r.likeCount + 1 WHERE r.id = :reviewId")
     void increaseLikeCount(@Param("reviewId") UUID reviewId);
 

--- a/src/test/java/com/codeit/team4/deokhugam/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/controller/CommentControllerTest.java
@@ -207,7 +207,7 @@ class CommentControllerTest {
         given(userService.findById(userId)).willReturn(mock(User.class));
         given(commentService.updateComment(any(UUID.class), any(UUID.class),
                 any(CommentUpdateRequest.class)))
-                .willThrow(new BusinessException(ErrorCode.UNAUTHORIZED_COMMENT_ACCESS));
+                .willThrow(new BusinessException(ErrorCode.COMMENT_NOT_OWNER));
 
         // when & then
         mockMvc.perform(patch("/api/comments/{commentId}", commentId)
@@ -216,7 +216,7 @@ class CommentControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
                 .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED_COMMENT_ACCESS"));
+                .andExpect(jsonPath("$.errorCode").value("COMMENT_NOT_OWNER"));
     }
 
     @Test
@@ -264,14 +264,14 @@ class CommentControllerTest {
         UUID userId = UUID.randomUUID();
 
         given(userService.findById(userId)).willReturn(mock(User.class));
-        willThrow(new BusinessException(ErrorCode.UNAUTHORIZED_COMMENT_ACCESS))
+        willThrow(new BusinessException(ErrorCode.COMMENT_NOT_OWNER))
                 .given(commentService).softDeleteComment(any(UUID.class), any(UUID.class));
 
         mockMvc.perform(delete("/api/comments/{commentId}", commentId)
                         .header("Deokhugam-Request-User-ID", userId.toString()))
                 .andDo(print())
                 .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED_COMMENT_ACCESS"));
+                .andExpect(jsonPath("$.errorCode").value("COMMENT_NOT_OWNER"));
     }
 
     @Test

--- a/src/test/java/com/codeit/team4/deokhugam/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/controller/CommentControllerTest.java
@@ -2,6 +2,7 @@ package com.codeit.team4.deokhugam.comment.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -15,6 +16,7 @@ import com.codeit.team4.deokhugam.comment.service.CommentService;
 import com.codeit.team4.deokhugam.global.config.AppProperties;
 import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.global.error.ErrorCode;
+import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
@@ -149,6 +151,8 @@ class CommentControllerTest {
         String updatedContent = "수정된 내용입니다";
         CommentUpdateRequest request = new CommentUpdateRequest(updatedContent);
 
+        given(userService.findById(userId)).willReturn(mock(User.class));
+
         CommentResponse response = new CommentResponse(
                 commentId, updatedContent, userId, reviewId,
                 "테스트닉네임", Instant.now(), Instant.now()
@@ -159,8 +163,7 @@ class CommentControllerTest {
                 .willReturn(response);
 
         // when & then
-        mockMvc.perform(patch(
-                        "/api/comments/{commentId}", commentId)
+        mockMvc.perform(patch("/api/comments/{commentId}", commentId)
                         .header("Deokhugam-Request-User-ID", userId.toString())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
@@ -178,9 +181,10 @@ class CommentControllerTest {
         UUID userId = UUID.randomUUID();
         CommentUpdateRequest invalidRequest = new CommentUpdateRequest(""); // 빈 문자열
 
+        given(userService.findById(userId)).willReturn(mock(User.class));
+
         // when & then
-        mockMvc.perform(patch(
-                        "/api/comments/{commentId}", commentId)
+        mockMvc.perform(patch("/api/comments/{commentId}", commentId)
                         .header("Deokhugam-Request-User-ID", userId.toString())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invalidRequest)))
@@ -194,17 +198,17 @@ class CommentControllerTest {
     void updateComment_Fail_403_Unauthorized() throws Exception {
         // given
         UUID commentId = UUID.randomUUID();
-        UUID requesterId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
         CommentUpdateRequest request = new CommentUpdateRequest("수정하려는 내용");
 
+        given(userService.findById(userId)).willReturn(mock(User.class));
         given(commentService.updateComment(any(UUID.class), any(UUID.class),
                 any(CommentUpdateRequest.class)))
                 .willThrow(new BusinessException(ErrorCode.UNAUTHORIZED_COMMENT_ACCESS));
 
         // when & then
-        mockMvc.perform(patch(
-                        "/api/comments/{commentId}", commentId)
-                        .header("Deokhugam-Request-User-ID", requesterId.toString())
+        mockMvc.perform(patch("/api/comments/{commentId}", commentId)
+                        .header("Deokhugam-Request-User-ID", userId.toString())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
@@ -220,13 +224,13 @@ class CommentControllerTest {
         UUID userId = UUID.randomUUID();
         CommentUpdateRequest request = new CommentUpdateRequest("수정하려는 내용");
 
+        given(userService.findById(userId)).willReturn(mock(User.class));
         given(commentService.updateComment(any(UUID.class), any(UUID.class),
                 any(CommentUpdateRequest.class)))
                 .willThrow(new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
 
         // when & then
-        mockMvc.perform(patch(
-                        "/api/comments/{commentId}", commentId)
+        mockMvc.perform(patch("/api/comments/{commentId}", commentId)
                         .header("Deokhugam-Request-User-ID", userId.toString())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))

--- a/src/test/java/com/codeit/team4/deokhugam/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/controller/CommentControllerTest.java
@@ -2,7 +2,10 @@ package com.codeit.team4.deokhugam.comment.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -237,5 +240,89 @@ class CommentControllerTest {
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.errorCode").value("COMMENT_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("댓글 논리 삭제 API 검증 성공")
+    void softDeleteComment_Success() throws Exception {
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        given(userService.findById(userId)).willReturn(mock(User.class));
+        willDoNothing().given(commentService).softDeleteComment(any(UUID.class), any(UUID.class));
+
+        mockMvc.perform(delete("/api/comments/{commentId}", commentId)
+                        .header("Deokhugam-Request-User-ID", userId.toString()))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("작성자가 일치하지 않아 댓글 논리 삭제 API 검증 실패")
+    void softDeleteComment_Fail_Unauthorized() throws Exception {
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        given(userService.findById(userId)).willReturn(mock(User.class));
+        willThrow(new BusinessException(ErrorCode.UNAUTHORIZED_COMMENT_ACCESS))
+                .given(commentService).softDeleteComment(any(UUID.class), any(UUID.class));
+
+        mockMvc.perform(delete("/api/comments/{commentId}", commentId)
+                        .header("Deokhugam-Request-User-ID", userId.toString()))
+                .andDo(print())
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value("UNAUTHORIZED_COMMENT_ACCESS"));
+    }
+
+    @Test
+    @DisplayName("요청자 ID 헤더가 누락되어 댓글 논리 삭제 API 검증 실패")
+    void softDeleteComment_Fail_400_MissingHeader() throws Exception {
+        // given
+        UUID commentId = UUID.randomUUID();
+
+        // when & then
+        mockMvc.perform(delete("/api/comments/{commentId}", commentId))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("MISSING_HEADER"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글로 인해 댓글 논리 삭제 API 검증 실패")
+    void softDeleteComment_Fail_404_NotFound() throws Exception {
+        // given
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        given(userService.findById(userId)).willReturn(mock(User.class));
+
+        willThrow(new BusinessException(ErrorCode.COMMENT_NOT_FOUND))
+                .given(commentService).softDeleteComment(any(UUID.class), any(UUID.class));
+
+        // when & then
+        mockMvc.perform(delete("/api/comments/{commentId}", commentId)
+                        .header("Deokhugam-Request-User-ID", userId.toString()))
+                .andDo(print())
+                .andExpect(status().isNotFound()) // 404 검증
+                .andExpect(jsonPath("$.errorCode").value("COMMENT_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("서버 내부 오류로 인해 댓글 논리 삭제 API 검증 실패")
+    void softDeleteComment_Fail_500_InternalServerError() throws Exception {
+        // given
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        given(userService.findById(userId)).willReturn(mock(User.class));
+
+        willThrow(new RuntimeException("Unexpected Database Error"))
+                .given(commentService).softDeleteComment(any(UUID.class), any(UUID.class));
+
+        // when & then
+        mockMvc.perform(delete("/api/comments/{commentId}", commentId)
+                        .header("Deokhugam-Request-User-ID", userId.toString()))
+                .andDo(print())
+                .andExpect(status().isInternalServerError());
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentServiceTest.java
@@ -184,7 +184,7 @@ class CommentServiceTest {
         // when & then
         assertThatThrownBy(() -> commentService.updateComment(commentId, requesterId, request))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED_COMMENT_ACCESS);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_OWNER);
     }
 
     @Test
@@ -250,7 +250,7 @@ class CommentServiceTest {
         // when & then
         assertThatThrownBy(() -> commentService.softDeleteComment(commentId, requesterId))
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED_COMMENT_ACCESS);
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_OWNER);
     }
 
     @Test

--- a/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentServiceTest.java
@@ -202,4 +202,72 @@ class CommentServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_FOUND);
     }
+
+    @Test
+    @DisplayName("권한이 일치하는 경우 댓글 논리 삭제와 댓글 카운트 감소 성공")
+    void softDeleteComment_Success() {
+        // given
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        UUID reviewId = UUID.randomUUID();
+
+        User mockUser = mock(User.class);
+        given(mockUser.getId()).willReturn(userId);
+
+        Review mockReview = mock(Review.class);
+        given(mockReview.getId()).willReturn(reviewId);
+
+        Comment mockComment = mock(Comment.class);
+        given(mockComment.getUser()).willReturn(mockUser);
+        given(mockComment.getReview()).willReturn(mockReview);
+
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(mockComment));
+
+        // when
+        commentService.softDeleteComment(commentId, userId);
+
+        // then
+        verify(mockComment).softDelete();
+        verify(reviewRepository).decreaseCommentCount(reviewId);
+    }
+
+    @Test
+    @DisplayName("작성자가 일치하지 않으면 댓글 논리 삭제 실패")
+    void softDeleteComment_Fail_Unauthorized() {
+        // given
+        UUID commentId = UUID.randomUUID();
+        UUID authorId = UUID.randomUUID();
+        UUID requesterId = UUID.randomUUID();
+
+        User mockAuthor = mock(User.class);
+        given(mockAuthor.getId()).willReturn(authorId);
+
+        Comment mockComment = mock(Comment.class);
+        given(mockComment.getUser()).willReturn(mockAuthor);
+
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(mockComment));
+
+        // when & then
+        assertThatThrownBy(() -> commentService.softDeleteComment(commentId, requesterId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED_COMMENT_ACCESS);
+    }
+
+    @Test
+    @DisplayName("이미 삭제된 댓글에 접근할 경우 실패")
+    void softDeleteComment_Fail_AlreadyDeleted() {
+        // given
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        Comment mockComment = mock(Comment.class);
+        given(mockComment.getDeletedAt()).willReturn(Instant.now());
+
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(mockComment));
+
+        // when & then
+        assertThatThrownBy(() -> commentService.softDeleteComment(commentId, userId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_FOUND);
+    }
 }


### PR DESCRIPTION
## 관련 이슈
- closes #53 

## 작업 내용
- 댓글 논리 삭제 기능 구현

## 변경 사항
- decreaseCommentCount 메서드 추가(ReviewRepository)
- 댓글 논리 삭제 테스트 케이스 추가
- 컨트롤러, 서비스에 논리 삭제 로직 추가

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 댓글 소프트 삭제 기능이 추가되었습니다. (DELETE /api/comments로 논리 삭제 가능)

* **버그 수정**
  * 삭제된 댓글이 기본 조회 결과에서 자동으로 필터링됩니다.
  * 댓글 삭제 시 연관된 리뷰의 댓글 수가 정상적으로 감소합니다.
  * 댓글 수정/삭제 권한 검증이 개선되어 관련 오류 응답이 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->