### PR TITLE
feat: 리뷰 생성/삭제 시 Book의 reviewCount 증감 처리

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/book/repository/BookRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/book/repository/BookRepository.java
@@ -4,9 +4,20 @@ import com.codeit.team4.deokhugam.book.entity.Book;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface BookRepository extends JpaRepository<Book, UUID> {
 
     Optional<Book> findByIdAndDeletedAtIsNull(UUID uuid);
     boolean existsByIsbnAndDeletedAtIsNull(String isbn);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Book b SET b.reviewCount = b.reviewCount + 1 WHERE b.id = :bookId")
+    void increaseReviewCount(@Param("bookId") UUID bookId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Book b SET b.reviewCount = b.reviewCount - 1 WHERE b.id = :bookId AND b.reviewCount > 0")
+    void decreaseReviewCount(@Param("bookId") UUID bookId);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/book/repository/BookRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/book/repository/BookRepository.java
@@ -13,11 +13,11 @@ public interface BookRepository extends JpaRepository<Book, UUID> {
     Optional<Book> findByIdAndDeletedAtIsNull(UUID uuid);
     boolean existsByIsbnAndDeletedAtIsNull(String isbn);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Book b SET b.reviewCount = b.reviewCount + 1 WHERE b.id = :bookId")
     void increaseReviewCount(@Param("bookId") UUID bookId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Book b SET b.reviewCount = b.reviewCount - 1 WHERE b.id = :bookId AND b.reviewCount > 0")
     void decreaseReviewCount(@Param("bookId") UUID bookId);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/review/repository/ReviewRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/repository/ReviewRepository.java
@@ -16,15 +16,15 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     Optional<Review> findByIdAndDeletedAtIsNull(@Param("id") UUID id);
 
     // 동시성 제어 + 서버 부하를 고려해 원자적 UPDATE 처리
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Review r SET r.commentCount = r.commentCount + 1 WHERE r.id = :reviewId")
     void increaseCommentCount(@Param("reviewId") UUID reviewId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Review r SET r.likeCount = r.likeCount + 1 WHERE r.id = :reviewId")
     void increaseLikeCount(@Param("reviewId") UUID reviewId);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Review r SET r.likeCount = r.likeCount - 1 WHERE r.id = :reviewId AND r.likeCount > 0")
     void decreaseLikeCount(@Param("reviewId") UUID reviewId);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
@@ -1,6 +1,7 @@
 package com.codeit.team4.deokhugam.review.service;
 
 import com.codeit.team4.deokhugam.book.entity.Book;
+import com.codeit.team4.deokhugam.book.repository.BookRepository;
 import com.codeit.team4.deokhugam.book.service.BookService;
 import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.global.error.ErrorCode;
@@ -32,6 +33,7 @@ public class ReviewService {
     private final ReviewLikeRepository reviewLikeRepository;
     private final UserService userService;
     private final BookService bookService;
+    private final BookRepository bookRepository;
     private final ReviewMapper reviewMapper;
 
     public ReviewResponse getReview(UUID reviewId, UUID userId) {
@@ -54,6 +56,7 @@ public class ReviewService {
             throw new BusinessException(
                     ErrorCode.DUPLICATE_REVIEW, "bookId=" + book.getId() + ", userId=" + user.getId());
         }
+        bookRepository.increaseReviewCount(book.getId());
         log.info("리뷰 생성 완료: reviewId={}", review.getId());
 
         return reviewMapper.toResponse(review, false);
@@ -89,6 +92,7 @@ public class ReviewService {
 
         validateReviewOwner(review, userId);
         review.softDelete();
+        bookRepository.decreaseReviewCount(review.getBook().getId());
         log.info("리뷰 논리 삭제 완료: reviewId={}", review.getId());
     }
 
@@ -97,6 +101,10 @@ public class ReviewService {
         Review review = findWithDeletedById(reviewId);
 
         validateReviewOwner(review, userId);
+        if (review.getDeletedAt() == null) {
+            bookRepository.decreaseReviewCount(review.getBook().getId());
+        }
+
         reviewRepository.delete(review);
         log.info("리뷰 물리 삭제 완료: reviewId={}", review.getId());
     }

--- a/src/test/java/com/codeit/team4/deokhugam/book/repository/BookRepositoryTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/book/repository/BookRepositoryTest.java
@@ -88,7 +88,7 @@ class BookRepositoryTest {
         }
 
         @Test
-        @DisplayName("리뷰 수 0 이하로 감소하지 않음")
+        @DisplayName("리뷰 수 0 이하로 감소하지 않음 성공")
         void decreaseReviewCount_notBelowZero_success() {
             bookRepository.decreaseReviewCount(book.getId());
             entityManager.flush();

--- a/src/test/java/com/codeit/team4/deokhugam/book/repository/BookRepositoryTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/book/repository/BookRepositoryTest.java
@@ -1,0 +1,101 @@
+package com.codeit.team4.deokhugam.book.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codeit.team4.deokhugam.book.entity.Book;
+import com.codeit.team4.deokhugam.config.TestContainerConfig;
+import com.codeit.team4.deokhugam.global.config.JpaAuditingConfig;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@Import({TestContainerConfig.class, JpaAuditingConfig.class})
+@ActiveProfiles("test")
+class BookRepositoryTest {
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private Book book;
+
+    @BeforeEach
+    void setUp() {
+        book = bookRepository.save(
+                new Book("클린 코드", "로버트 마틴", "좋은 책", "출판사",
+                        LocalDate.of(2024, 1, 1), "1234567890")
+        );
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Nested
+    @DisplayName("리뷰 수 증가")
+    class IncreaseReviewCount {
+
+        @Test
+        @DisplayName("리뷰 수 증가 성공")
+        void increaseReviewCount_success() {
+            bookRepository.increaseReviewCount(book.getId());
+            entityManager.flush();
+            entityManager.clear();
+
+            Book found = bookRepository.findById(book.getId()).orElseThrow();
+            assertThat(found.getReviewCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("리뷰 수 여러 번 증가 성공")
+        void increaseReviewCount_multiple_success() {
+            bookRepository.increaseReviewCount(book.getId());
+            bookRepository.increaseReviewCount(book.getId());
+            bookRepository.increaseReviewCount(book.getId());
+            entityManager.flush();
+            entityManager.clear();
+
+            Book found = bookRepository.findById(book.getId()).orElseThrow();
+            assertThat(found.getReviewCount()).isEqualTo(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 수 감소")
+    class DecreaseReviewCount {
+
+        @Test
+        @DisplayName("리뷰 수 감소 성공")
+        void decreaseReviewCount_success() {
+            bookRepository.increaseReviewCount(book.getId());
+            entityManager.flush();
+            entityManager.clear();
+
+            bookRepository.decreaseReviewCount(book.getId());
+            entityManager.flush();
+            entityManager.clear();
+
+            Book found = bookRepository.findById(book.getId()).orElseThrow();
+            assertThat(found.getReviewCount()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("리뷰 수 0 이하로 감소하지 않음")
+        void decreaseReviewCount_notBelowZero_success() {
+            bookRepository.decreaseReviewCount(book.getId());
+            entityManager.flush();
+            entityManager.clear();
+
+            Book found = bookRepository.findById(book.getId()).orElseThrow();
+            assertThat(found.getReviewCount()).isEqualTo(0);
+        }
+    }
+}

--- a/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewServiceTest.java
@@ -6,9 +6,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.codeit.team4.deokhugam.book.entity.Book;
+import com.codeit.team4.deokhugam.book.repository.BookRepository;
 import com.codeit.team4.deokhugam.book.service.BookService;
 import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.global.error.ErrorCode;
@@ -51,6 +53,9 @@ class ReviewServiceTest {
 
     @Mock
     private BookService bookService;
+
+    @Mock
+    private BookRepository bookRepository;
 
     @Mock
     private ReviewMapper reviewMapper;
@@ -96,6 +101,7 @@ class ReviewServiceTest {
             assertThat(response.content()).isEqualTo("좋은 책입니다");
             assertThat(response.rating()).isEqualTo(5);
             verify(reviewRepository).save(any(Review.class));
+            verify(bookRepository).increaseReviewCount(bookId);
         }
 
         @Test
@@ -117,6 +123,7 @@ class ReviewServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.DUPLICATE_REVIEW));
+            verify(bookRepository, never()).increaseReviewCount(any());
         }
 
         @Test
@@ -133,6 +140,7 @@ class ReviewServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.USER_NOT_FOUND));
+            verify(bookRepository, never()).increaseReviewCount(any());
         }
 
         @Test
@@ -151,6 +159,7 @@ class ReviewServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.BOOK_NOT_FOUND));
+            verify(bookRepository, never()).increaseReviewCount(any());
         }
 
         @Test
@@ -174,6 +183,7 @@ class ReviewServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.DUPLICATE_REVIEW));
+            verify(bookRepository, never()).increaseReviewCount(any());
         }
     }
 
@@ -342,14 +352,19 @@ class ReviewServiceTest {
         void softDeleteReview_success() {
             UUID reviewId = UUID.randomUUID();
             UUID userId = UUID.randomUUID();
+            UUID bookId = UUID.randomUUID();
             Review review = mock(Review.class);
+            Book book = mock(Book.class);
 
             given(reviewRepository.findByIdAndDeletedAtIsNull(reviewId)).willReturn(Optional.of(review));
             given(review.isOwner(userId)).willReturn(true);
+            given(review.getBook()).willReturn(book);
+            given(book.getId()).willReturn(bookId);
 
             reviewService.softDeleteReview(reviewId, userId);
 
             verify(review).softDelete();
+            verify(bookRepository).decreaseReviewCount(bookId);
         }
 
         @Test
@@ -367,6 +382,7 @@ class ReviewServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.REVIEW_NOT_OWNER));
+            verify(bookRepository, never()).decreaseReviewCount(any());
         }
 
         @Test
@@ -381,6 +397,7 @@ class ReviewServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.REVIEW_NOT_FOUND));
+            verify(bookRepository, never()).decreaseReviewCount(any());
         }
     }
 
@@ -450,17 +467,40 @@ class ReviewServiceTest {
     class HardDeleteReview {
 
         @Test
-        @DisplayName("리뷰 물리 삭제 성공")
-        void hardDeleteReview_success() {
+        @DisplayName("논리 삭제되지 않은 리뷰 물리 삭제 성공")
+        void hardDeleteReview_notSoftDeleted_success() {
+            UUID reviewId = UUID.randomUUID();
+            UUID userId = UUID.randomUUID();
+            UUID bookId = UUID.randomUUID();
+            Review review = mock(Review.class);
+            Book book = mock(Book.class);
+
+            given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+            given(review.isOwner(userId)).willReturn(true);
+            given(review.getDeletedAt()).willReturn(null);
+            given(review.getBook()).willReturn(book);
+            given(book.getId()).willReturn(bookId);
+
+            reviewService.hardDeleteReview(reviewId, userId);
+
+            verify(bookRepository).decreaseReviewCount(bookId);
+            verify(reviewRepository).delete(review);
+        }
+
+        @Test
+        @DisplayName("이미 논리 삭제된 리뷰 물리 삭제 성공")
+        void hardDeleteReview_alreadySoftDeleted_success() {
             UUID reviewId = UUID.randomUUID();
             UUID userId = UUID.randomUUID();
             Review review = mock(Review.class);
 
             given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
             given(review.isOwner(userId)).willReturn(true);
+            given(review.getDeletedAt()).willReturn(Instant.now());
 
             reviewService.hardDeleteReview(reviewId, userId);
 
+            verify(bookRepository, never()).decreaseReviewCount(any());
             verify(reviewRepository).delete(review);
         }
 
@@ -479,6 +519,7 @@ class ReviewServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.REVIEW_NOT_OWNER));
+            verify(bookRepository, never()).decreaseReviewCount(any());
         }
 
         @Test
@@ -493,6 +534,7 @@ class ReviewServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.REVIEW_NOT_FOUND));
+            verify(bookRepository, never()).decreaseReviewCount(any());
         }
     }
 }


### PR DESCRIPTION
## 관련 이슈
- closes #150

## 작업 내용
- 리뷰 생성/삭제 시 Book 엔티티의 reviewCount를 자동으로 증감하도록 구현

## 변경 사항

  BookRepository

  - increaseReviewCount(bookId) - reviewCount +1 (JPQL UPDATE)
  - decreaseReviewCount(bookId) - reviewCount -1 (0 이하로 내려가지 않도록 조건 포함)

  ReviewService

  - 리뷰 생성 시 increaseReviewCount 호출
  - 리뷰 논리 삭제 시 decreaseReviewCount 호출
  - 리뷰 물리 삭제 시 논리 삭제되지 않은 리뷰인 경우에만 decreaseReviewCount 호출 (이중 차감 방지)

  BookRepositoryTest (신규)

  - 리뷰 수 증가 성공
  - 리뷰 수 여러 번 증가 성공
  - 리뷰 수 감소 성공
  - 리뷰 수 0 이하로 감소하지 않음

  ReviewServiceTest (수정)

  - 리뷰 생성 성공 시 increaseReviewCount 호출 검증
  - 리뷰 생성 실패 시 increaseReviewCount 미호출 검증 (중복, 사용자 없음, 도서 없음, DB 무결성 위반)
  - 리뷰 논리 삭제 성공 시 decreaseReviewCount 호출 검증
  - 리뷰 논리 삭제 실패 시 decreaseReviewCount 미호출 검증 (권한 없음, 리뷰 없음)
  - 논리 삭제되지 않은 리뷰 물리 삭제 시 decreaseReviewCount 호출 검증
  - 이미 논리 삭제된 리뷰 물리 삭제 시 decreaseReviewCount 미호출 검증
  - 리뷰 물리 삭제 실패 시 decreaseReviewCount 미호출 검증 (권한 없음, 리뷰 없음)   
    
## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 책의 리뷰 수를 자동으로 추적 및 관리하는 기능 추가
  * 리뷰 생성 시 리뷰 카운트 자동 증가
  * 리뷰 삭제 시 리뷰 카운트 자동 감소

* **테스트**
  * 리뷰 카운트 증가/감소 동작 검증 테스트 추가
  * 리뷰 생성/삭제 시 카운트 업데이트 동작 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->