### PR TITLE
feat: 댓글 물리 삭제 구현

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/comment/controller/CommentController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/controller/CommentController.java
@@ -53,7 +53,6 @@ public class CommentController implements CommentApi {
                 commentService.updateComment(commentId, loginUser.userId(), request));
     }
 
-    @Override
     @DeleteMapping("/{commentId}")
     public ResponseEntity<Void> softDeleteComment(
             @PathVariable UUID commentId,
@@ -62,6 +61,18 @@ public class CommentController implements CommentApi {
         log.info("댓글 논리 삭제 요청: commentId={}, userId={}", commentId, loginUser.userId());
 
         commentService.softDeleteComment(commentId, loginUser.userId());
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{commentId}/hard")
+    public ResponseEntity<Void> hardDeleteComment(
+            @PathVariable UUID commentId,
+            @LoginUser DeokhugamUser loginUser) {
+
+        log.info("댓글 물리 삭제 요청: commentId={}, userId={}", commentId, loginUser.userId());
+
+        commentService.hardDeleteComment(commentId, loginUser.userId());
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/controller/api/CommentApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/controller/api/CommentApi.java
@@ -93,4 +93,28 @@ public interface CommentApi {
             @LoginUser DeokhugamUser loginUser
     );
 
+    @Operation(summary = "댓글 물리 삭제", description = "본인이 작성한 댓글을 물리적으로 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "댓글 삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (요청자 ID 누락)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "댓글 삭제 권한 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "댓글 정보 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @Parameters({
+            @Parameter(
+                    name = "Deokhugam-Request-User-ID",
+                    in = ParameterIn.HEADER,
+                    required = true,
+                    description = "요청자 ID")
+    })
+    ResponseEntity<Void> hardDeleteComment(
+            @Parameter(description = "댓글 ID", required = true) @PathVariable UUID commentId,
+            @LoginUser DeokhugamUser loginUser
+    );
+
 }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/repository/CommentRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/repository/CommentRepository.java
@@ -1,9 +1,27 @@
 package com.codeit.team4.deokhugam.comment.repository;
 
 import com.codeit.team4.deokhugam.comment.entity.Comment;
+import java.time.Instant;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository extends JpaRepository<Comment, UUID> {
 
+    // 논리 삭제: deleted_at이 NULL일 때만 현재 시간으로 업데이트
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Comment c SET c.deletedAt = :now WHERE c.id = :id AND c.deletedAt IS NULL")
+    int softDeleteWithCondition(@Param("id") UUID id, @Param("now") Instant now);
+
+    // 물리 삭제: deleted_at이 NULL일 때만 Row 삭제
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM Comment c WHERE c.id = :id AND c.deletedAt IS NULL")
+    int hardDeleteWithCondition(@Param("id") UUID id);
+
+    // 물리 삭제: 상태와 상관없이 삭제할 때 사용(이미 논리 삭제된 상태일 때)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM Comment c WHERE c.id = :id")
+    int hardDeleteForce(@Param("id") UUID id);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
@@ -56,14 +56,13 @@ public class CommentService {
 
         comment.updateContent(request.content());
 
-        log.info("댓글 수정 완료: commentId: {}, userId: {}", commentId, userId);
+        log.info("댓글 수정 완료: commentId={}, userId={}", commentId, userId);
         return commentMapper.toResponse(comment);
     }
 
     @Transactional
     public void softDeleteComment(UUID commentId, UUID userId) {
         Comment comment = findCommentById(commentId);
-
         validateCommentOwner(comment, userId, "논리 삭제");
 
         comment.softDelete();
@@ -85,10 +84,9 @@ public class CommentService {
         if (comment.getDeletedAt() == null) {
             reviewRepository.decreaseCommentCount(comment.getReview().getId());
         }
-
         commentRepository.delete(comment);
 
-        log.info("Comment hard-deleted successfully. commentId: {}", commentId);
+        log.info("댓글 물리 삭제 완료: commentId={}, userId={}", commentId, userId);
     }
 
     // ========== Private Methods ==========
@@ -109,7 +107,7 @@ public class CommentService {
         if (!comment.getUser().getId().equals(userId)) {
             throw new BusinessException(
                     ErrorCode.COMMENT_NOT_OWNER,
-                    String.format("댓글 %s 권한 없음 - commentId: %s, 요청자: %s", action, comment.getId(),
+                    String.format("댓글 %s 권한 없음 - commentId=%s, 요청자=%s", action, comment.getId(),
                             userId)
             );
         }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
@@ -50,7 +50,8 @@ public class CommentService {
     }
 
     @Transactional
-    public CommentResponse updateComment(UUID commentId, UUID userId, CommentUpdateRequest request) {
+    public CommentResponse updateComment(UUID commentId, UUID userId,
+            CommentUpdateRequest request) {
         Comment comment = findCommentById(commentId);
 
         validateCommentOwner(comment, userId, "수정");
@@ -70,7 +71,7 @@ public class CommentService {
 
         if (updatedRows == 1) {
             reviewRepository.decreaseCommentCount(comment.getReview().getId());
-            log.info("댓글 논리 삭제 및 카운트 감소 완료: commentId={}", commentId);
+            log.info("댓글 논리 삭제 완료: commentId={}, userId={}", commentId, userId);
         } else {
             throw new BusinessException(ErrorCode.COMMENT_NOT_FOUND, "이미 처리된 요청입니다.");
         }
@@ -106,7 +107,8 @@ public class CommentService {
                         ErrorCode.COMMENT_NOT_FOUND, "commentId: " + commentId));
 
         if (comment.getDeletedAt() != null) {
-            throw new BusinessException(ErrorCode.COMMENT_NOT_FOUND, "이미 삭제된 댓글입니다. commentId: " + commentId);
+            throw new BusinessException(ErrorCode.COMMENT_NOT_FOUND,
+                    "이미 삭제된 댓글입니다. commentId: " + commentId);
         }
 
         return comment;

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
@@ -13,6 +13,7 @@ import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
 import com.codeit.team4.deokhugam.review.service.ReviewService;
 import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.service.UserService;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -65,10 +66,14 @@ public class CommentService {
         Comment comment = findCommentById(commentId);
         validateCommentOwner(comment, userId, "논리 삭제");
 
-        comment.softDelete();
-        reviewRepository.decreaseCommentCount(comment.getReview().getId());
+        int updatedRows = commentRepository.softDeleteWithCondition(commentId, Instant.now());
 
-        log.info("댓글 논리 삭제 완료: commentId={}, userId={}", commentId, userId);
+        if (updatedRows == 1) {
+            reviewRepository.decreaseCommentCount(comment.getReview().getId());
+            log.info("댓글 논리 삭제 및 카운트 감소 완료: commentId={}", commentId);
+        } else {
+            throw new BusinessException(ErrorCode.COMMENT_NOT_FOUND, "이미 처리된 요청입니다.");
+        }
     }
 
     @Transactional
@@ -80,11 +85,15 @@ public class CommentService {
 
         validateCommentOwner(comment, userId, "물리 삭제");
 
-        // 논리 삭제되지 않은 데이터를 물리 삭제할 때만 카운트 감소
+        // 논리 삭제 여부에 따른 분기 처리
         if (comment.getDeletedAt() == null) {
-            reviewRepository.decreaseCommentCount(comment.getReview().getId());
+            int updatedRows = commentRepository.hardDeleteWithCondition(commentId);
+            if (updatedRows == 1) {
+                reviewRepository.decreaseCommentCount(comment.getReview().getId());
+            }
+        } else {
+            commentRepository.hardDeleteForce(commentId);
         }
-        commentRepository.delete(comment);
 
         log.info("댓글 물리 삭제 완료: commentId={}, userId={}", commentId, userId);
     }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
@@ -73,7 +73,9 @@ public class CommentService {
             reviewRepository.decreaseCommentCount(comment.getReview().getId());
             log.info("댓글 논리 삭제 완료: commentId={}, userId={}", commentId, userId);
         } else {
-            throw new BusinessException(ErrorCode.COMMENT_NOT_FOUND, "이미 처리된 요청입니다.");
+            throw new BusinessException(
+                    ErrorCode.COMMENT_NOT_FOUND,
+                    String.format("이미 처리된 요청입니다: commentId=%s, userId=%s", commentId, userId));
         }
     }
 

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentService.java
@@ -72,6 +72,25 @@ public class CommentService {
         log.info("댓글 논리 삭제 완료: commentId={}, userId={}", commentId, userId);
     }
 
+    @Transactional
+    public void hardDeleteComment(UUID commentId, UUID userId) {
+        // 이미 논리 삭제된 것도 물리 삭제 가능해야 하므로 findById 사용
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new BusinessException(
+                        ErrorCode.COMMENT_NOT_FOUND, "commentId: " + commentId));
+
+        validateCommentOwner(comment, userId, "물리 삭제");
+
+        // 논리 삭제되지 않은 데이터를 물리 삭제할 때만 카운트 감소
+        if (comment.getDeletedAt() == null) {
+            reviewRepository.decreaseCommentCount(comment.getReview().getId());
+        }
+
+        commentRepository.delete(comment);
+
+        log.info("Comment hard-deleted successfully. commentId: {}", commentId);
+    }
+
     // ========== Private Methods ==========
 
     private Comment findCommentById(UUID commentId) {
@@ -95,5 +114,4 @@ public class CommentService {
             );
         }
     }
-
 }

--- a/src/test/java/com/codeit/team4/deokhugam/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/controller/CommentControllerTest.java
@@ -325,4 +325,89 @@ class CommentControllerTest {
                 .andDo(print())
                 .andExpect(status().isInternalServerError());
     }
+
+    @Test
+    @DisplayName("댓글 물리 삭제 API 검증 성공")
+    void hardDeleteComment_Api_Success() throws Exception {
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        given(userService.findById(userId)).willReturn(mock(User.class));
+        willDoNothing().given(commentService).hardDeleteComment(any(UUID.class), any(UUID.class));
+
+        mockMvc.perform(delete("/api/comments/{commentId}/hard", commentId)
+                        .header("Deokhugam-Request-User-ID", userId.toString()))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("요청자 ID 헤더가 누락되어 댓글 물리 삭제 API 검증 실패")
+    void hardDeleteComment_Fail_400_MissingHeader() throws Exception {
+        // given
+        UUID commentId = UUID.randomUUID();
+
+        // when & then
+        mockMvc.perform(delete("/api/comments/{commentId}/hard", commentId))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value("MISSING_HEADER"));
+    }
+
+    @Test
+    @DisplayName("댓글 작성자가 일치하지 않아 물리 삭제 API 권한 검증 실패")
+    void hardDeleteComment_Fail_403_Forbidden() throws Exception {
+        // given
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        given(userService.findById(userId)).willReturn(mock(User.class));
+        willThrow(new BusinessException(ErrorCode.COMMENT_NOT_OWNER))
+                .given(commentService).hardDeleteComment(any(UUID.class), any(UUID.class));
+
+        // when & then
+        mockMvc.perform(delete("/api/comments/{commentId}/hard", commentId)
+                        .header("Deokhugam-Request-User-ID", userId.toString()))
+                .andDo(print())
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.errorCode").value("COMMENT_NOT_OWNER"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글 식별자로 물리 삭제 API 조회 실패")
+    void hardDeleteComment_Fail_404_NotFound() throws Exception {
+        // given
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        given(userService.findById(userId)).willReturn(mock(User.class));
+        willThrow(new BusinessException(ErrorCode.COMMENT_NOT_FOUND))
+                .given(commentService).hardDeleteComment(any(UUID.class), any(UUID.class));
+
+        // when & then
+        mockMvc.perform(delete("/api/comments/{commentId}/hard", commentId)
+                        .header("Deokhugam-Request-User-ID", userId.toString()))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("COMMENT_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("서버 내부 오류 발생 시 물리 삭제 API 응답 실패")
+    void hardDeleteComment_Fail_500_InternalServerError() throws Exception {
+        // given
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        given(userService.findById(userId)).willReturn(mock(User.class));
+        willThrow(new RuntimeException("Unexpected DB Error"))
+                .given(commentService).hardDeleteComment(any(UUID.class), any(UUID.class));
+
+        // when & then
+        mockMvc.perform(delete("/api/comments/{commentId}/hard", commentId)
+                        .header("Deokhugam-Request-User-ID", userId.toString()))
+                .andDo(print())
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.errorCode").value("INTERNAL_SERVER_ERROR"));
+    }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentServiceTest.java
@@ -355,10 +355,10 @@ class CommentServiceTest {
         // given
         UUID commentId = UUID.randomUUID();
         UUID requesterId = UUID.randomUUID();
-        UUID userId = UUID.randomUUID();
+        UUID authorId = UUID.randomUUID();
 
         User mockAuthor = mock(User.class);
-        given(mockAuthor.getId()).willReturn(userId);
+        given(mockAuthor.getId()).willReturn(authorId);
 
         Comment mockComment = mock(Comment.class);
         given(mockComment.getUser()).willReturn(mockAuthor);

--- a/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentServiceTest.java
@@ -270,4 +270,48 @@ class CommentServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_FOUND);
     }
+
+    @Test
+    @DisplayName("권한이 일치하면 댓글 물리 삭제 성공")
+    void hardDeleteComment_Success() {
+        // given
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        UUID reviewId = UUID.randomUUID();
+
+        User mockUser = mock(User.class);
+        given(mockUser.getId()).willReturn(userId);
+
+        Review mockReview = mock(Review.class);
+        given(mockReview.getId()).willReturn(reviewId);
+
+        Comment mockComment = mock(Comment.class);
+        given(mockComment.getUser()).willReturn(mockUser);
+        given(mockComment.getReview()).willReturn(mockReview);
+
+        // 아직 논리 삭제되지 않은 상태라고 가정
+        given(mockComment.getDeletedAt()).willReturn(null);
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(mockComment));
+
+        // when
+        commentService.hardDeleteComment(commentId, userId);
+
+        // then
+        verify(commentRepository).delete(mockComment);
+        verify(reviewRepository).decreaseCommentCount(reviewId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글 식별자로는 물리 삭제 실패")
+    void hardDeleteComment_Fail_NotFound() {
+        // given
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        given(commentRepository.findById(commentId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> commentService.hardDeleteComment(commentId, userId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_FOUND);
+    }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -313,5 +314,56 @@ class CommentServiceTest {
         assertThatThrownBy(() -> commentService.hardDeleteComment(commentId, userId))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("논리 삭제된 댓글은 댓글 카운트 유지한 상태로 물리 삭제 성공")
+    void hardDeleteComment_Success_AlreadyLogicallyDeleted() {
+        // given
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        User mockUser = mock(User.class);
+        given(mockUser.getId()).willReturn(userId);
+
+        Comment mockComment = mock(Comment.class);
+        given(mockComment.getUser()).willReturn(mockUser);
+
+        given(mockComment.getDeletedAt()).willReturn(java.time.Instant.now());
+
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(mockComment));
+
+        // when
+        commentService.hardDeleteComment(commentId, userId);
+
+        // then
+        verify(commentRepository).delete(mockComment);
+        // 카운트 감소 메서드는 호출되지 않아야 함
+        verify(reviewRepository, never()).decreaseCommentCount(any());
+    }
+
+    @Test
+    @DisplayName("댓글 작성자가 일치하지 않아 물리 삭제 실패")
+    void hardDeleteComment_Fail_NotOwner() {
+        // given
+        UUID commentId = UUID.randomUUID();
+        UUID requesterId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+
+        User mockAuthor = mock(User.class);
+        given(mockAuthor.getId()).willReturn(userId);
+
+        Comment mockComment = mock(Comment.class);
+        given(mockComment.getUser()).willReturn(mockAuthor);
+
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(mockComment));
+
+        // when & then
+        assertThatThrownBy(() -> commentService.hardDeleteComment(commentId, requesterId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_OWNER);
+
+        verify(commentRepository, never()).delete(any());
+        verify(reviewRepository, never()).decreaseCommentCount(any());
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentServiceTest.java
@@ -3,6 +3,7 @@ package com.codeit.team4.deokhugam.comment.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
@@ -223,18 +224,19 @@ class CommentServiceTest {
         given(mockComment.getReview()).willReturn(mockReview);
 
         given(commentRepository.findById(commentId)).willReturn(Optional.of(mockComment));
+        given(commentRepository.softDeleteWithCondition(eq(commentId), any(Instant.class))).willReturn(1);
 
         // when
         commentService.softDeleteComment(commentId, userId);
 
         // then
-        verify(mockComment).softDelete();
+        verify(commentRepository).softDeleteWithCondition(eq(commentId), any(Instant.class));
         verify(reviewRepository).decreaseCommentCount(reviewId);
     }
 
     @Test
     @DisplayName("작성자가 일치하지 않으면 댓글 논리 삭제 실패")
-    void softDeleteComment_Fail_Unauthorized() {
+    void softDeleteComment_Fail_NotOwner() {
         // given
         UUID commentId = UUID.randomUUID();
         UUID authorId = UUID.randomUUID();
@@ -252,6 +254,9 @@ class CommentServiceTest {
         assertThatThrownBy(() -> commentService.softDeleteComment(commentId, requesterId))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_OWNER);
+
+        verify(commentRepository, never()).softDeleteWithCondition(any(), any());
+        verify(reviewRepository, never()).decreaseCommentCount(any());
     }
 
     @Test
@@ -293,12 +298,13 @@ class CommentServiceTest {
         // 아직 논리 삭제되지 않은 상태라고 가정
         given(mockComment.getDeletedAt()).willReturn(null);
         given(commentRepository.findById(commentId)).willReturn(Optional.of(mockComment));
+        given(commentRepository.hardDeleteWithCondition(commentId)).willReturn(1);
 
         // when
         commentService.hardDeleteComment(commentId, userId);
 
         // then
-        verify(commentRepository).delete(mockComment);
+        verify(commentRepository).hardDeleteWithCondition(commentId);
         verify(reviewRepository).decreaseCommentCount(reviewId);
     }
 
@@ -332,12 +338,13 @@ class CommentServiceTest {
         given(mockComment.getDeletedAt()).willReturn(java.time.Instant.now());
 
         given(commentRepository.findById(commentId)).willReturn(Optional.of(mockComment));
+        given(commentRepository.hardDeleteForce(commentId)).willReturn(1);
 
         // when
         commentService.hardDeleteComment(commentId, userId);
 
         // then
-        verify(commentRepository).delete(mockComment);
+        verify(commentRepository).hardDeleteForce(commentId);
         // 카운트 감소 메서드는 호출되지 않아야 함
         verify(reviewRepository, never()).decreaseCommentCount(any());
     }
@@ -363,7 +370,8 @@ class CommentServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_OWNER);
 
-        verify(commentRepository, never()).delete(any());
+        verify(commentRepository, never()).hardDeleteWithCondition(any());
+        verify(commentRepository, never()).hardDeleteForce(any());
         verify(reviewRepository, never()).decreaseCommentCount(any());
     }
 }


### PR DESCRIPTION
## 관련 이슈
- closes #54

## 작업 내용
- 댓글 물리 삭제 기능 구현

## 변경 사항
- 컨트롤러, 서비스에 댓글 물리 삭제 기능 추가(hardDeleteComment)
- 단위 테스트 구현

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 댓글 물리 삭제 기능 추가 — 하드 삭제 엔드포인트로 댓글을 완전히 삭제할 수 있습니다. 기존 권한 검증이 적용됩니다.

* **변경 사항**
  * 소프트 삭제 처리 로직이 조건부로 강화되어 중복 요청에 대한 처리 안정성이 개선되었습니다.

* **테스트**
  * 하드 삭제 및 소프트 삭제 동작을 검증하는 단위·통합 테스트 추가/갱신 (성공/실패 케이스 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->