### PR TITLE
fix: 리뷰 목록에서 totalCount 누락 수정

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewQueryService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewQueryService.java
@@ -5,11 +5,15 @@ import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
 import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
 
 import com.codeit.team4.deokhugam.global.response.PageResponse;
+import com.codeit.team4.deokhugam.jooq.tables.Books;
+import com.codeit.team4.deokhugam.jooq.tables.Reviews;
+import com.codeit.team4.deokhugam.jooq.tables.Users;
 import com.codeit.team4.deokhugam.review.dto.ReviewResponse;
 import com.codeit.team4.deokhugam.review.model.ReviewSearchModel;
 import com.codeit.team4.deokhugam.review.dto.ReviewSearchRequestParam;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
 import org.springframework.stereotype.Service;
@@ -54,6 +58,19 @@ public class ReviewQueryService {
                 .map(ReviewResponse::from)
                 .toList();
 
-        return new PageResponse<>(reviews, nextCursor, nextAfter, param.limit(), null, hasNext);
+        long totalElements = getTotalElements(param);
+
+        return new PageResponse<>(reviews, nextCursor, nextAfter, param.limit(), totalElements, hasNext);
+    }
+
+    private long getTotalElements(ReviewSearchRequestParam param) {
+        return Optional.ofNullable(
+                dsl.selectCount()
+                        .from(Reviews.REVIEWS)
+                        .join(Books.BOOKS).on(Reviews.REVIEWS.BOOK_ID.eq(Books.BOOKS.ID))
+                        .join(Users.USERS).on(Reviews.REVIEWS.USER_ID.eq(Users.USERS.ID))
+                        .where(conditionBuilder.toFilterCondition(param))
+                        .fetchOne(0, Long.class))
+                .orElse(0L);
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewQueryService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewQueryService.java
@@ -66,9 +66,9 @@ public class ReviewQueryService {
     private long getTotalElements(ReviewSearchRequestParam param) {
         return Optional.ofNullable(
                 dsl.selectCount()
-                        .from(Reviews.REVIEWS)
-                        .join(Books.BOOKS).on(Reviews.REVIEWS.BOOK_ID.eq(Books.BOOKS.ID))
-                        .join(Users.USERS).on(Reviews.REVIEWS.USER_ID.eq(Users.USERS.ID))
+                        .from(REVIEWS)
+                        .join(BOOKS).on(REVIEWS.BOOK_ID.eq(BOOKS.ID))
+                        .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
                         .where(conditionBuilder.toFilterCondition(param))
                         .fetchOne(0, Long.class))
                 .orElse(0L);

--- a/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewSearchConditionBuilder.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewSearchConditionBuilder.java
@@ -21,6 +21,16 @@ import org.springframework.stereotype.Component;
 public class ReviewSearchConditionBuilder {
 
     public Condition toCondition(ReviewSearchRequestParam param) {
+        Condition condition = toFilterCondition(param);
+
+        if (param.cursor() != null && param.after() != null) {
+            condition = condition.and(toCursorCondition(param));
+        }
+
+        return condition;
+    }
+
+    public Condition toFilterCondition(ReviewSearchRequestParam param) {
         Condition condition = REVIEWS.DELETED_AT.isNull();
 
         if (param.keyword() != null && !param.keyword().isBlank()) {
@@ -35,9 +45,6 @@ public class ReviewSearchConditionBuilder {
         }
         if (param.bookId() != null) {
             condition = condition.and(REVIEWS.BOOK_ID.eq(param.bookId()));
-        }
-        if (param.cursor() != null && param.after() != null) {
-            condition = condition.and(toCursorCondition(param));
         }
 
         return condition;

--- a/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewQueryServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewQueryServiceTest.java
@@ -82,6 +82,7 @@ class ReviewQueryServiceTest {
             PageResponse<ReviewResponse> result = reviewQueryService.searchReviews(param);
 
             assertThat(result.content()).hasSize(2);
+            assertThat(result.totalElements()).isEqualTo(2);
             assertThat(result.hasNext()).isFalse();
         }
     }
@@ -107,6 +108,7 @@ class ReviewQueryServiceTest {
             PageResponse<ReviewResponse> result = reviewQueryService.searchReviews(param);
 
             assertThat(result.content()).hasSize(2);
+            assertThat(result.totalElements()).isEqualTo(3);
             assertThat(result.hasNext()).isTrue();
             assertThat(result.nextCursor()).isNotNull();
             assertThat(result.nextAfter()).isNotNull();
@@ -136,6 +138,7 @@ class ReviewQueryServiceTest {
             PageResponse<ReviewResponse> secondResult = reviewQueryService.searchReviews(secondPage);
 
             assertThat(secondResult.content()).hasSize(1);
+            assertThat(secondResult.totalElements()).isEqualTo(3);
             assertThat(secondResult.hasNext()).isFalse();
             // 1페이지와 2페이지 리뷰가 중복 없이 전체를 커버하는지 검증
             List<UUID> allIds = new ArrayList<>(firstResult.content().stream().map(ReviewResponse::id).toList());
@@ -171,6 +174,7 @@ class ReviewQueryServiceTest {
             PageResponse<ReviewResponse> secondResult = reviewQueryService.searchReviews(secondPage);
 
             assertThat(secondResult.content()).hasSize(1);
+            assertThat(secondResult.totalElements()).isEqualTo(3);
             assertThat(secondResult.content().get(0).rating()).isEqualTo(1);
             assertThat(secondResult.hasNext()).isFalse();
         }
@@ -194,6 +198,7 @@ class ReviewQueryServiceTest {
             PageResponse<ReviewResponse> result = reviewQueryService.searchReviews(param);
 
             assertThat(result.content()).hasSize(1);
+            assertThat(result.totalElements()).isEqualTo(1);
             assertThat(result.content().get(0).likedByMe()).isTrue();
         }
 
@@ -210,6 +215,7 @@ class ReviewQueryServiceTest {
             PageResponse<ReviewResponse> result = reviewQueryService.searchReviews(param);
 
             assertThat(result.content()).hasSize(1);
+            assertThat(result.totalElements()).isEqualTo(1);
             assertThat(result.content().get(0).likedByMe()).isFalse();
         }
     }


### PR DESCRIPTION
## 관련 이슈
- closes #133

## 작업 내용
- ReviewQueryService.searchReviews에서 totalElements를 실제 count 쿼리로 반환하도록 수정한 건에 맞춰 기존 테스트에 totalElements 검증 추가

## 변경 사항
  - ReviewQueryServiceTest 6개 테스트에 totalElements assertion 추가                                                                                                                                                                                                                                                        
    - 기본 조회, 페이지네이션(hasNext, 커서, rating 커서), 좋아요 여부 테스트 각각에 기대값 검증

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 리뷰 검색 결과의 페이지네이션에서 전체 항목 개수 정보가 정확하게 계산되어 제공됩니다.
* **리팩터**
  * 검색 조건 구성 로직이 필터와 커서 조건으로 분리되어 가독성·유지보수성이 향상되었습니다.
* **테스트**
  * 페이지네이션 및 전체 항목 수 관련 테스트가 강화되어 다양한 시나리오에서 검증됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->