### PR TITLE
feat: 알림 읽음 처리 기능 구현

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
@@ -35,6 +35,9 @@ public enum ErrorCode {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다"),
     COMMENT_NOT_OWNER(HttpStatus.FORBIDDEN, "해당 댓글을 수정/삭제할 권한이 없습니다"),
 
+    // Notification
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
+
     // Naver API
     NAVER_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "네이버 API 호출에 실패했습니다.");
 

--- a/src/main/java/com/codeit/team4/deokhugam/notification/controller/NotificationController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/notification/controller/NotificationController.java
@@ -7,9 +7,13 @@ import com.codeit.team4.deokhugam.notification.service.NotificationService;
 import com.codeit.team4.deokhugam.global.annotation.LoginUser;
 import com.codeit.team4.deokhugam.global.dto.DeokhugamUser;
 import java.time.Instant;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,6 +25,33 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationController implements NotificationApi {
 
     private final NotificationService notificationService;
+
+    @Override
+    @PatchMapping("/{notificationId}")
+    public ResponseEntity<NotificationResponse> markAsRead(
+            @PathVariable UUID notificationId,
+            @LoginUser DeokhugamUser loginUser
+    ) {
+        log.info("알림 읽음 처리 요청: notificationId={}, userId={}",
+                notificationId, loginUser.userId());
+
+        NotificationResponse response =
+                notificationService.markAsRead(notificationId, loginUser.userId());
+
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    @PatchMapping("/read-all")
+    public ResponseEntity<Void> markAllAsRead(
+            @LoginUser DeokhugamUser loginUser
+    ) {
+        log.info("전체 알림 읽음 처리 요청: userId={}", loginUser.userId());
+
+        notificationService.markAllAsRead(loginUser.userId());
+
+        return ResponseEntity.noContent().build();
+    }
 
     @Override
     @GetMapping

--- a/src/main/java/com/codeit/team4/deokhugam/notification/controller/api/NotificationApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/notification/controller/api/NotificationApi.java
@@ -14,10 +14,65 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.Instant;
+import java.util.UUID;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "알림 관리", description = "알림 관련 API")
 public interface NotificationApi {
+
+    @Operation(summary = "알림 읽음 상태 업데이트", description = "특정 알림을 읽음 상태로 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "알림 상태 업데이트 성공",
+                    content = @Content(schema = @Schema(implementation = NotificationResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "403", description = "알림 수정 권한 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "알림 정보 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @Parameter(
+            name = "Deokhugam-Request-User-ID",
+            in = ParameterIn.HEADER,
+            required = true,
+            description = "요청자 ID",
+            example = "123e4567-e89b-12d3-a456-426614174000"
+    )
+    ResponseEntity<NotificationResponse> markAsRead(
+            @Parameter(
+                    description = "알림 ID",
+                    required = true,
+                    example = "123e4567-e89b-12d3-a456-426614174000"
+            )
+            @PathVariable UUID notificationId,
+
+            @LoginUser DeokhugamUser loginUser
+    );
+
+    @Operation(summary = "모든 알림 읽음 처리", description = "사용자의 모든 알림을 읽음 상태로 처리합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "알림 읽음 처리 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "사용자 정보 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @Parameter(
+            name = "Deokhugam-Request-User-ID",
+            in = ParameterIn.HEADER,
+            required = true,
+            description = "사용자 ID",
+            example = "123e4567-e89b-12d3-a456-426614174000"
+    )
+    ResponseEntity<Void> markAllAsRead(
+            @LoginUser DeokhugamUser loginUser
+    );
 
     @Operation(summary = "알림 목록 조회", description = "사용자의 알림 목록을 조회합니다.")
     @ApiResponses({

--- a/src/main/java/com/codeit/team4/deokhugam/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/notification/repository/NotificationRepository.java
@@ -1,10 +1,12 @@
 package com.codeit.team4.deokhugam.notification.repository;
 
 import com.codeit.team4.deokhugam.notification.entity.Notification;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID> {
     Optional<Notification> findByIdAndUserId(UUID id, UUID userId);
+    List<Notification> findByUserIdAndConfirmedFalse(UUID userId);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/notification/repository/NotificationRepository.java
@@ -1,8 +1,10 @@
 package com.codeit.team4.deokhugam.notification.repository;
 
 import com.codeit.team4.deokhugam.notification.entity.Notification;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+    Optional<Notification> findByIdAndUserId(UUID id, UUID userId);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/notification/service/NotificationService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/notification/service/NotificationService.java
@@ -34,12 +34,17 @@ public class NotificationService {
             UUID notificationId,
             UUID loginUserId
     ) {
+
         Notification notification = notificationRepository
-                .findByIdAndUserId(notificationId, loginUserId)
+                .findById(notificationId)
                 .orElseThrow(() -> new BusinessException(
                         ErrorCode.NOTIFICATION_NOT_FOUND,
                         "notificationId=" + notificationId
                 ));
+
+        if (!notification.getUserId().equals(loginUserId)) {
+            throw new BusinessException(ErrorCode.USER_FORBIDDEN);
+        }
 
         if (!notification.isConfirmed()) {
             notification.markAsRead();

--- a/src/main/java/com/codeit/team4/deokhugam/notification/service/NotificationService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/notification/service/NotificationService.java
@@ -1,37 +1,64 @@
 package com.codeit.team4.deokhugam.notification.service;
 
+import com.codeit.team4.deokhugam.global.error.BusinessException;
+import com.codeit.team4.deokhugam.global.error.ErrorCode;
 import com.codeit.team4.deokhugam.global.response.PageResponse;
 import com.codeit.team4.deokhugam.notification.dto.NotificationResponse;
-import com.codeit.team4.deokhugam.notification.dto.NotificationUpdateRequest;
+import com.codeit.team4.deokhugam.notification.entity.Notification;
 import com.codeit.team4.deokhugam.notification.model.NotificationModel;
 import com.codeit.team4.deokhugam.notification.repository.NotificationRepository;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class NotificationService {
 
     private final NotificationQueryService notificationQueryService;
+
+    private final NotificationRepository notificationRepository;
 
     // TODO: 구현 예정
     public void createNotification(UUID receiverId, UUID reviewId, String reviewContent, String message) {
     }
 
-    // TODO: 구현 예정
     @Transactional
-    public NotificationResponse markAsRead(UUID notificationId, UUID loginUserId, NotificationUpdateRequest request) {
-        return null;
+    public NotificationResponse markAsRead(
+            UUID notificationId,
+            UUID loginUserId
+    ) {
+        Notification notification = notificationRepository
+                .findByIdAndUserId(notificationId, loginUserId)
+                .orElseThrow(() -> new BusinessException(
+                        ErrorCode.NOTIFICATION_NOT_FOUND,
+                        "notificationId=" + notificationId
+                ));
+
+        if (!notification.isConfirmed()) {
+            notification.markAsRead();
+            log.info("알림 읽음 처리 완료: notificationId={}, userId={}", notificationId, loginUserId);
+        }
+
+        return toResponseFromEntity(notification);
     }
 
-    // TODO: 구현 예정
     @Transactional
-    public void markAllAsRead(UUID loginUserId) {
+    public void markAllAsRead(UUID userId) {
+        List<Notification> notifications =
+                notificationRepository.findByUserIdAndConfirmedFalse(userId);
+
+        notifications.forEach(Notification::markAsRead);
+
+        if (!notifications.isEmpty()) {
+            log.info("전체 알림 읽음 처리 완료: userId={}, count={}", userId, notifications.size());
+        }
     }
 
     public PageResponse<NotificationResponse> getNotifications(
@@ -55,7 +82,7 @@ public class NotificationService {
                 hasNext ? notifications.subList(0, size) : notifications;
 
         List<NotificationResponse> content = pageItems.stream()
-                .map(this::toResponse)
+                .map(this::toResponseFromEntity)
                 .toList();
 
         String nextCursor = null;
@@ -83,7 +110,8 @@ public class NotificationService {
     }
 
     // 헬퍼 메서드
-    private NotificationResponse toResponse(NotificationModel n) {
+    // JOOQ 조회 결과 → DTO
+    private NotificationResponse toResponseFromEntity(NotificationModel n) {
         return new NotificationResponse(
                 n.id(),
                 n.userId(),
@@ -93,6 +121,20 @@ public class NotificationService {
                 n.confirmed(),
                 n.createdAt(),
                 n.updatedAt()
+        );
+    }
+
+    // JPA 엔티티 → DTO
+    private NotificationResponse toResponseFromEntity(Notification n) {
+        return new NotificationResponse(
+                n.getId(),
+                n.getUserId(),
+                n.getReviewId(),
+                n.getReviewContent(),
+                n.getMessage(),
+                n.isConfirmed(),
+                n.getCreatedAt(),
+                n.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/notification/service/NotificationService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/notification/service/NotificationService.java
@@ -43,7 +43,10 @@ public class NotificationService {
                 ));
 
         if (!notification.getUserId().equals(loginUserId)) {
-            throw new BusinessException(ErrorCode.USER_FORBIDDEN);
+            throw new BusinessException(
+                    ErrorCode.USER_FORBIDDEN,
+                    "notificationId=" + notificationId + ", loginUserId=" + loginUserId
+            );
         }
 
         if (!notification.isConfirmed()) {

--- a/src/test/java/com/codeit/team4/deokhugam/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/notification/controller/NotificationControllerTest.java
@@ -1,10 +1,16 @@
 package com.codeit.team4.deokhugam.notification.controller;
 
 import com.codeit.team4.deokhugam.global.config.AppProperties;
+import com.codeit.team4.deokhugam.global.error.BusinessException;
+import com.codeit.team4.deokhugam.global.error.ErrorCode;
 import com.codeit.team4.deokhugam.global.response.PageResponse;
 import com.codeit.team4.deokhugam.notification.dto.NotificationResponse;
 import com.codeit.team4.deokhugam.notification.service.NotificationService;
 import com.codeit.team4.deokhugam.user.service.UserService;
+
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +29,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -42,6 +48,108 @@ class NotificationControllerTest {
     private NotificationService notificationService;
 
     private static final String USER_HEADER = "Deokhugam-Request-User-ID";
+
+    @Test
+    @DisplayName("알림 읽음 처리 요청이 정상 처리되어 성공")
+    void markAsRead_success() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID notificationId = UUID.randomUUID();
+
+        NotificationResponse response = new NotificationResponse(
+                notificationId,
+                userId,
+                UUID.randomUUID(),
+                "review content",
+                "message",
+                true,
+                Instant.now(),
+                Instant.now()
+        );
+
+        given(notificationService.markAsRead(notificationId, userId))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(patch("/api/notifications/{notificationId}", notificationId)
+                        .header(USER_HEADER, userId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.confirmed").value(true))
+                .andExpect(jsonPath("$.message").value("message"));
+
+        then(notificationService)
+                .should()
+                .markAsRead(notificationId, userId);
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 알림이면 읽음 처리 실패")
+    void markAsRead_forbidden_fail() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID notificationId = UUID.randomUUID();
+
+        given(notificationService.markAsRead(notificationId, userId))
+                .willThrow(new BusinessException(ErrorCode.USER_FORBIDDEN));
+
+        // when & then
+        mockMvc.perform(patch("/api/notifications/{notificationId}", notificationId)
+                        .header(USER_HEADER, userId.toString()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("알림이 존재하지 않으면 읽음 처리 실패")
+    void markAsRead_notFound_fail() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID notificationId = UUID.randomUUID();
+
+        given(notificationService.markAsRead(notificationId, userId))
+                .willThrow(new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(patch("/api/notifications/{notificationId}", notificationId)
+                        .header(USER_HEADER, userId.toString()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("모든 알림 읽음 처리 요청이 정상 처리되어 성공")
+    void markAllAsRead_success() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+
+        // when & then
+        mockMvc.perform(patch("/api/notifications/read-all")
+                        .header(USER_HEADER, userId.toString()))
+                .andExpect(status().isNoContent());
+
+        then(notificationService)
+                .should()
+                .markAllAsRead(userId);
+    }
+
+    @Test
+    @DisplayName("사용자가 없으면 전체 읽음 처리 실패")
+    void markAllAsRead_userNotFound_fail() throws Exception {
+
+        // given
+        UUID userId = UUID.randomUUID();
+
+        willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND))
+                .given(notificationService)
+                .markAllAsRead(userId);
+
+        // when & then
+        mockMvc.perform(patch("/api/notifications/read-all")
+                        .header(USER_HEADER, userId.toString()))
+                .andExpect(status().isNotFound());
+    }
 
     @Test
     @DisplayName("로그인 사용자의 알림 목록 조회 요청이 정상 처리되어서 알림 목록 조회 성공")

--- a/src/test/java/com/codeit/team4/deokhugam/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/notification/controller/NotificationControllerTest.java
@@ -142,13 +142,15 @@ class NotificationControllerTest {
         UUID userId = UUID.randomUUID();
 
         willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND))
-                .given(notificationService)
-                .markAllAsRead(userId);
+                .given(userService)
+                .findById(userId);
 
         // when & then
         mockMvc.perform(patch("/api/notifications/read-all")
                         .header(USER_HEADER, userId.toString()))
                 .andExpect(status().isNotFound());
+
+        then(notificationService).shouldHaveNoInteractions();
     }
 
     @Test

--- a/src/test/java/com/codeit/team4/deokhugam/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/notification/repository/NotificationRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.codeit.team4.deokhugam.notification.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.codeit.team4.deokhugam.book.entity.Book;
 import com.codeit.team4.deokhugam.book.repository.BookRepository;
@@ -121,9 +120,9 @@ class NotificationRepositoryTest {
     }
 
     @Test
-    @DisplayName("모든 알림이 읽음 상태일 때 조회하면 결과 없음으로 실패")
-    void findByUserIdAndConfirmedFalse_whenAllRead_thenFail() {
-        // given
+    @DisplayName("모든 알림이 읽음 상태일 때 조회하면 빈 결과가 반환된다")
+    void findByUserIdAndConfirmedFalse_whenAllRead_thenEmpty() {
+// given
         User user = createDummyUser();
         Book book = createDummyBook();
         Review review = createDummyReview(user, book);
@@ -133,11 +132,11 @@ class NotificationRepositoryTest {
         );
         read.markAsRead();
 
-        // when
+// when
         List<Notification> result =
                 notificationRepository.findByUserIdAndConfirmedFalse(user.getId());
 
-        // then
+// then
         assertThat(result).isEmpty();
     }
 

--- a/src/test/java/com/codeit/team4/deokhugam/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/notification/repository/NotificationRepositoryTest.java
@@ -1,0 +1,123 @@
+package com.codeit.team4.deokhugam.notification.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.codeit.team4.deokhugam.book.entity.Book;
+import com.codeit.team4.deokhugam.book.repository.BookRepository;
+import com.codeit.team4.deokhugam.config.TestContainerConfig;
+import com.codeit.team4.deokhugam.global.config.JpaAuditingConfig;
+import com.codeit.team4.deokhugam.notification.entity.Notification;
+import com.codeit.team4.deokhugam.review.entity.Review;
+import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
+import com.codeit.team4.deokhugam.user.entity.User;
+import com.codeit.team4.deokhugam.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import({TestContainerConfig.class, JpaAuditingConfig.class})
+class NotificationRepositoryTest {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Test
+    @DisplayName("알림 ID와 userId가 일치하면 조회 성공")
+    void findByIdAndUserId_success() {
+        // given
+        User user = createDummyUser();
+        Book book = createDummyBook();
+        Review review = createDummyReview(user, book);
+
+        Notification notification = new Notification(
+                user.getId(),
+                review.getId(),
+                "content",
+                "message"
+        );
+
+        Notification saved = notificationRepository.save(notification);
+
+        // when
+        Optional<Notification> result =
+                notificationRepository.findByIdAndUserId(saved.getId(), saved.getUserId());
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getUserId()).isEqualTo(user.getId());
+    }
+
+    @Test
+    @DisplayName("다른 userId로 조회하면 조회 실패")
+    void findByIdAndUserId_fail() {
+        // given
+        User user = createDummyUser();
+        Book book = createDummyBook();
+        Review review = createDummyReview(user, book);
+
+        Notification notification = new Notification(
+                user.getId(),
+                review.getId(),
+                "content",
+                "message"
+        );
+
+        Notification saved = notificationRepository.save(notification);
+
+        // when
+        Optional<Notification> result =
+                notificationRepository.findByIdAndUserId(saved.getId(), UUID.randomUUID());
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    // 헬퍼 메서드
+    private User createDummyUser() {
+        return userRepository.save(
+                new User(
+                        "test-" + UUID.randomUUID() + "@test.com",
+                        "testUser",
+                        "password1!"
+                )
+        );
+    }
+
+    private Book createDummyBook() {
+        Book book = new Book(
+                "test book",
+                "author",
+                "description",
+                "publisher",
+                LocalDate.now(),
+                "isbn-" + UUID.randomUUID()
+        );
+        return bookRepository.save(book);
+    }
+
+    private Review createDummyReview(User user, Book book) {
+        Review review = new Review(
+                book,
+                user,
+                "review content",
+                5
+        );
+        return reviewRepository.save(review);
+    }
+}

--- a/src/test/java/com/codeit/team4/deokhugam/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/notification/repository/NotificationRepositoryTest.java
@@ -13,6 +13,7 @@ import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
 import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.repository.UserRepository;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -88,6 +89,86 @@ class NotificationRepositoryTest {
         assertThat(result).isEmpty();
     }
 
+    @Test
+    @DisplayName("읽지 않은 알림이 존재할 때 userId로 조회하면 성공")
+    void findByUserIdAndConfirmedFalse_whenUnreadExists_thenSuccess() {
+        // given
+        User user = createDummyUser();
+        Book book = createDummyBook();
+        Review review = createDummyReview(user, book);
+
+        Notification unread1 = notificationRepository.save(
+                new Notification(user.getId(), review.getId(), "content1", "message1")
+        );
+
+        Notification unread2 = notificationRepository.save(
+                new Notification(user.getId(), review.getId(), "content2", "message2")
+        );
+
+        Notification read = notificationRepository.save(
+                new Notification(user.getId(), review.getId(), "content3", "message3")
+        );
+        read.markAsRead();
+
+        // when
+        List<Notification> result =
+                notificationRepository.findByUserIdAndConfirmedFalse(user.getId());
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(Notification::getId)
+                .containsExactlyInAnyOrder(unread1.getId(), unread2.getId());
+    }
+
+    @Test
+    @DisplayName("모든 알림이 읽음 상태일 때 조회하면 결과 없음으로 실패")
+    void findByUserIdAndConfirmedFalse_whenAllRead_thenFail() {
+        // given
+        User user = createDummyUser();
+        Book book = createDummyBook();
+        Review review = createDummyReview(user, book);
+
+        Notification read = notificationRepository.save(
+                new Notification(user.getId(), review.getId(), "content", "message")
+        );
+        read.markAsRead();
+
+        // when
+        List<Notification> result =
+                notificationRepository.findByUserIdAndConfirmedFalse(user.getId());
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("다른 userId의 알림을 조회하면 필터링되어 조회 실패")
+    void findByUserIdAndConfirmedFalse_whenOtherUser_thenFail() {
+        // given
+        User user1 = createDummyUser();
+        User user2 = createDummyUser();
+
+        Book book = createDummyBook();
+        Review review1 = createDummyReview(user1, book);
+        Review review2 = createDummyReview(user2, book);
+
+        notificationRepository.save(
+                new Notification(user1.getId(), review1.getId(), "content1", "message1")
+        );
+
+        notificationRepository.save(
+                new Notification(user2.getId(), review2.getId(), "content2", "message2")
+        );
+
+        // when
+        List<Notification> result =
+                notificationRepository.findByUserIdAndConfirmedFalse(user1.getId());
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getUserId()).isEqualTo(user1.getId());
+    }
+
     // 헬퍼 메서드
     private User createDummyUser() {
         return userRepository.save(
@@ -106,7 +187,7 @@ class NotificationRepositoryTest {
                 "description",
                 "publisher",
                 LocalDate.now(),
-                "isbn-" + UUID.randomUUID()
+                "isbn-123"
         );
         return bookRepository.save(book);
     }

--- a/src/test/java/com/codeit/team4/deokhugam/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/notification/service/NotificationServiceTest.java
@@ -1,6 +1,7 @@
 package com.codeit.team4.deokhugam.notification.service;
 
 import com.codeit.team4.deokhugam.global.error.BusinessException;
+import com.codeit.team4.deokhugam.global.error.ErrorCode;
 import com.codeit.team4.deokhugam.global.response.PageResponse;
 import com.codeit.team4.deokhugam.notification.dto.NotificationResponse;
 import com.codeit.team4.deokhugam.notification.entity.Notification;
@@ -53,7 +54,7 @@ class NotificationServiceTest {
                 "message"
         );
 
-        given(notificationRepository.findByIdAndUserId(notificationId, userId))
+        given(notificationRepository.findById(notificationId))
                 .willReturn(Optional.of(notification));
 
         // when
@@ -73,9 +74,10 @@ class NotificationServiceTest {
 
         Notification notification = mock(Notification.class);
 
-        given(notificationRepository.findByIdAndUserId(notificationId, userId))
+        given(notificationRepository.findById(notificationId))
                 .willReturn(Optional.of(notification));
 
+        given(notification.getUserId()).willReturn(userId);
         given(notification.isConfirmed()).willReturn(true);
 
         // when
@@ -86,13 +88,13 @@ class NotificationServiceTest {
     }
 
     @Test
-    @DisplayName("알림이 존재하지 않거나 권한이 없으면 조회 실패")
-    void markAsRead_whenNotFoundOrNotOwner_thenFail() {
+    @DisplayName("알림이 존재하지 않으면 조회 실패")
+    void markAsRead_whenNotFound_thenFail() {
         // given
         UUID userId = UUID.randomUUID();
         UUID notificationId = UUID.randomUUID();
 
-        given(notificationRepository.findByIdAndUserId(notificationId, userId))
+        given(notificationRepository.findById(notificationId))
                 .willReturn(Optional.empty());
 
         // when & then
@@ -101,6 +103,30 @@ class NotificationServiceTest {
         )
                 .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("notificationId=" + notificationId);
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 알림이면 읽음 처리 실패")
+    void markAsRead_whenNotOwner_thenFail() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID otherUserId = UUID.randomUUID();
+        UUID notificationId = UUID.randomUUID();
+
+        Notification notification = mock(Notification.class);
+
+        given(notificationRepository.findById(notificationId))
+                .willReturn(Optional.of(notification));
+
+        given(notification.getUserId()).willReturn(otherUserId);
+
+        // when & then
+        assertThatThrownBy(() ->
+                notificationService.markAsRead(notificationId, userId)
+        )
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_FORBIDDEN);
     }
 
     @Test

--- a/src/test/java/com/codeit/team4/deokhugam/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/notification/service/NotificationServiceTest.java
@@ -1,8 +1,12 @@
 package com.codeit.team4.deokhugam.notification.service;
 
+import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.global.response.PageResponse;
 import com.codeit.team4.deokhugam.notification.dto.NotificationResponse;
+import com.codeit.team4.deokhugam.notification.entity.Notification;
 import com.codeit.team4.deokhugam.notification.model.NotificationModel;
+import com.codeit.team4.deokhugam.notification.repository.NotificationRepository;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,7 +19,13 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationServiceTest {
@@ -25,6 +35,136 @@ class NotificationServiceTest {
 
     @Mock
     NotificationQueryService notificationQueryService;
+
+    @Mock
+    NotificationRepository notificationRepository;
+
+    @Test
+    @DisplayName("읽지 않은 알림을 읽음 처리하여 성공")
+    void markAsRead_whenUnread_thenSuccess() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID notificationId = UUID.randomUUID();
+
+        Notification notification = new Notification(
+                userId,
+                UUID.randomUUID(),
+                "content",
+                "message"
+        );
+
+        given(notificationRepository.findByIdAndUserId(notificationId, userId))
+                .willReturn(Optional.of(notification));
+
+        // when
+        NotificationResponse result =
+                notificationService.markAsRead(notificationId, userId);
+
+        // then
+        assertThat(result.confirmed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미 읽은 알림은 추가 처리 없이 성공")
+    void markAsRead_whenAlreadyRead_thenSuccess() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID notificationId = UUID.randomUUID();
+
+        Notification notification = mock(Notification.class);
+
+        given(notificationRepository.findByIdAndUserId(notificationId, userId))
+                .willReturn(Optional.of(notification));
+
+        given(notification.isConfirmed()).willReturn(true);
+
+        // when
+        notificationService.markAsRead(notificationId, userId);
+
+        // then
+        then(notification).should(never()).markAsRead();
+    }
+
+    @Test
+    @DisplayName("알림이 존재하지 않거나 권한이 없으면 조회 실패")
+    void markAsRead_whenNotFoundOrNotOwner_thenFail() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UUID notificationId = UUID.randomUUID();
+
+        given(notificationRepository.findByIdAndUserId(notificationId, userId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() ->
+                notificationService.markAsRead(notificationId, userId)
+        )
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("notificationId=" + notificationId);
+    }
+
+    @Test
+    @DisplayName("읽지 않은 알림 여러 개를 모두 읽음 처리하여 성공")
+    void markAllAsRead_whenUnreadExists_thenSuccess() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        Notification n1 = mock(Notification.class);
+        Notification n2 = mock(Notification.class);
+
+        given(notificationRepository.findByUserIdAndConfirmedFalse(userId))
+                .willReturn(List.of(n1, n2));
+
+        // when
+        notificationService.markAllAsRead(userId);
+
+        // then
+        then(n1).should().markAsRead();
+        then(n2).should().markAsRead();
+        then(notificationRepository).should()
+                .findByUserIdAndConfirmedFalse(userId);
+    }
+
+    @Test
+    @DisplayName("읽지 않은 알림이 없으면 조회만 수행되고 아무 동작 없이 성공")
+    void markAllAsRead_whenNoUnread_thenSuccess() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        given(notificationRepository.findByUserIdAndConfirmedFalse(userId))
+                .willReturn(List.of());
+
+        // when
+        notificationService.markAllAsRead(userId);
+
+        // then
+        then(notificationRepository).should(times(1))
+                .findByUserIdAndConfirmedFalse(userId);
+    }
+
+    @Test
+    @DisplayName("여러 알림 중 일부 처리 중 오류 발생 시 전체 처리 실패")
+    void markAllAsRead_whenPartialFailure_thenFail() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        Notification n1 = mock(Notification.class);
+        Notification n2 = mock(Notification.class);
+
+        given(notificationRepository.findByUserIdAndConfirmedFalse(userId))
+                .willReturn(List.of(n1, n2));
+
+        willThrow(new RuntimeException("중간 실패"))
+                .given(n2).markAsRead();
+
+        // when & then
+        assertThatThrownBy(() ->
+                notificationService.markAllAsRead(userId)
+        ).isInstanceOf(RuntimeException.class);
+
+        then(n1).should().markAsRead();
+        then(n2).should().markAsRead();
+    }
 
     @Test
     @DisplayName("DTO 변환 및 페이징 응답이 정상적으로 반환되어서 알림 목록 조회 성공")


### PR DESCRIPTION
## 관련 이슈
- closes #61 

## 작업 내용

### 1. 단일 알림 읽음 처리
- 특정 Notification을 읽음 상태로 변경 (confirmed = true)
- 읽지 않은 알림만 상태 변경 수행
- 알림 소유자 검증 후 처리 수행

### 2. 전체 알림 읽음 처리
- 해당 사용자의 모든 미확인 알림을 읽음 상태로 변경
- 조회된 알림 목록에 대해 일괄 처리 수행

### 3. 권한 검증
- 로그인 사용자와 알림 소유자(userId) 일치 여부 검증
- 알림은 존재하지만 타인의 경우 403(FORBIDDEN) 처리
- 본인 알림만 수정 가능하도록 정책 적용

### 4. 예외 처리
- 존재하지 않는 알림 조회 시 404(NOTIFICATION_NOT_FOUND) 발생
- 권한 없는 접근 시 403(USER_FORBIDDEN) 발생
- 사용자 존재하지 않는 경우 404(USER_NOT_FOUND) 처리
- 전체 처리 중 예상치 못한 오류 발생 시 예외 전파

### 5. 테스트 코드
- NotificationService 단위 테스트 작성
- NotificationController WebMvcTest 작성
- 성공 / 실패 / 예외 케이스 모두 포함
- 403 / 404 분리 정책에 맞춰 테스트 검증

## 변경 사항
- 주요 변경 사항을 작성해주세요.

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 개별 알림을 읽음으로 표시할 수 있는 기능 추가
  * 모든 알림을 한 번에 읽음 처리하는 기능 추가

* **버그 수정**
  * 존재하지 않는 알림 조회 시 404 오류 응답 추가
  * 알림 조회 실패 시 명확한 오류 메시지 제공

* **개선 사항**
  * 알림 상태 관리 강화로 사용자 경험 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->