### PR TITLE
feat: 대시보드 인기 리뷰 구현

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PopularBookAggregationQueryBuilder.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PopularBookAggregationQueryBuilder.java
@@ -40,7 +40,7 @@ public class PopularBookAggregationQueryBuilder {
                         .mul(PopularBook.AVG_RATING_WEIGHT))
                 .desc();
 
-        return List.of(scoreDesc, BOOKS.CREATED_AT.asc());
+        return List.of(scoreDesc, BOOKS.CREATED_AT.asc(), REVIEWS.BOOK_ID.asc());
     }
 
     private Condition startDateCondition(PeriodType period, LocalDate snapshotDate) {

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PopularReviewAggregationQueryBuilder.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PopularReviewAggregationQueryBuilder.java
@@ -4,7 +4,7 @@ import static com.codeit.team4.deokhugam.jooq.tables.Books.BOOKS;
 import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
 
 import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
-import com.codeit.team4.deokhugam.dashboard.entity.PopularBook;
+import com.codeit.team4.deokhugam.dashboard.entity.PopularReview;
 import java.math.BigDecimal;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -19,7 +19,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-public class PopularBookAggregationQueryBuilder {
+public class PopularReviewAggregationQueryBuilder {
 
     @Value("${dashboard.batch.zone}")
     private String zone;
@@ -34,13 +34,13 @@ public class PopularBookAggregationQueryBuilder {
     }
 
     public List<SortField<?>> buildOrderBy() {
-        SortField<?> scoreDesc = DSL.count().cast(BigDecimal.class)
-                .mul(PopularBook.REVIEW_COUNT_WEIGHT)
-                .add(DSL.avg(REVIEWS.RATING).cast(BigDecimal.class)
-                        .mul(PopularBook.AVG_RATING_WEIGHT))
+        SortField<?> scoreDesc = REVIEWS.LIKE_COUNT.cast(BigDecimal.class)
+                .mul(PopularReview.LIKE_COUNT_WEIGHT)
+                .add(REVIEWS.COMMENT_COUNT.cast(BigDecimal.class)
+                        .mul(PopularReview.COMMENT_COUNT_WEIGHT))
                 .desc();
 
-        return List.of(scoreDesc, BOOKS.CREATED_AT.asc());
+        return List.of(scoreDesc, REVIEWS.CREATED_AT.asc());
     }
 
     private Condition startDateCondition(PeriodType period, LocalDate snapshotDate) {

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PopularReviewAggregationQueryBuilder.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PopularReviewAggregationQueryBuilder.java
@@ -40,7 +40,7 @@ public class PopularReviewAggregationQueryBuilder {
                         .mul(PopularReview.COMMENT_COUNT_WEIGHT))
                 .desc();
 
-        return List.of(scoreDesc, REVIEWS.CREATED_AT.asc());
+        return List.of(scoreDesc, REVIEWS.CREATED_AT.asc(), REVIEWS.ID.asc());
     }
 
     private Condition startDateCondition(PeriodType period, LocalDate snapshotDate) {

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PopularReviewReadQueryBuilder.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PopularReviewReadQueryBuilder.java
@@ -1,6 +1,6 @@
 package com.codeit.team4.deokhugam.dashboard.builder;
 
-import static com.codeit.team4.deokhugam.jooq.tables.PopularBooks.POPULAR_BOOKS;
+import static com.codeit.team4.deokhugam.jooq.tables.PopularReviews.POPULAR_REVIEWS;
 
 import com.codeit.team4.deokhugam.dashboard.dto.DashboardSearchRequestParam;
 import com.codeit.team4.deokhugam.global.response.SortDirection;
@@ -11,20 +11,20 @@ import org.jooq.impl.DSL;
 import org.springframework.stereotype.Component;
 
 @Component
-public class PopularBookReadQueryBuilder {
+public class PopularReviewReadQueryBuilder {
 
     public Condition buildCondition(DashboardSearchRequestParam param, LocalDate latestSnapshotDate) {
         return DSL.and(
-                POPULAR_BOOKS.PERIOD.eq(param.period().name()),
-                POPULAR_BOOKS.SNAPSHOT_DATE.eq(latestSnapshotDate),
+                POPULAR_REVIEWS.PERIOD.eq(param.period().name()),
+                POPULAR_REVIEWS.SNAPSHOT_DATE.eq(latestSnapshotDate),
                 rankCondition(param)
         );
     }
 
     public SortField<?> buildOrderBy(SortDirection direction) {
         return SortDirection.ASC == direction
-                ? POPULAR_BOOKS.RANK.asc()
-                : POPULAR_BOOKS.RANK.desc();
+                ? POPULAR_REVIEWS.RANK.asc()
+                : POPULAR_REVIEWS.RANK.desc();
     }
 
     private Condition rankCondition(DashboardSearchRequestParam param) {
@@ -35,8 +35,8 @@ public class PopularBookReadQueryBuilder {
         }
 
         return switch (param.direction()) {
-            case ASC -> POPULAR_BOOKS.RANK.gt(cursor);
-            case DESC -> POPULAR_BOOKS.RANK.lt(cursor);
+            case ASC -> POPULAR_REVIEWS.RANK.gt(cursor);
+            case DESC -> POPULAR_REVIEWS.RANK.lt(cursor);
         };
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/controller/DashboardController.java
@@ -1,9 +1,10 @@
 package com.codeit.team4.deokhugam.dashboard.controller;
 
-import com.codeit.team4.deokhugam.dashboard.dto.PopularBookResponse;
-import com.codeit.team4.deokhugam.dashboard.dto.PopularBookSearchRequestParam;
 import com.codeit.team4.deokhugam.dashboard.controller.api.DashboardApi;
-import com.codeit.team4.deokhugam.dashboard.service.DashboardService;
+import com.codeit.team4.deokhugam.dashboard.dto.DashboardSearchRequestParam;
+import com.codeit.team4.deokhugam.dashboard.dto.PopularBookResponse;
+import com.codeit.team4.deokhugam.dashboard.dto.PopularReviewResponse;
+import com.codeit.team4.deokhugam.dashboard.service.DashboardFacade;
 import com.codeit.team4.deokhugam.global.response.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,15 +21,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class DashboardController implements DashboardApi {
 
-    private final DashboardService dashboardService;
+    private final DashboardFacade dashboardService;
 
     @GetMapping("/books/popular")
     public ResponseEntity<PageResponse<PopularBookResponse>> getPopularBooks(
-            @Valid @ParameterObject PopularBookSearchRequestParam param
+            @Valid @ParameterObject DashboardSearchRequestParam param
     ) {
         log.info("인기 도서 목록 조회 요청: period={}, direction={}, limit={}",
                 param.period(), param.direction(), param.limit());
 
         return ResponseEntity.ok(dashboardService.getPopularBooks(param));
+    }
+
+    @GetMapping("/reviews/popular")
+    public ResponseEntity<PageResponse<PopularReviewResponse>> getPopularReviews(
+            @Valid @ParameterObject DashboardSearchRequestParam param
+    ) {
+        log.info("인기 리뷰 목록 조회 요청: period={}, direction={}, limit={}",
+                param.period(), param.direction(), param.limit());
+
+        return ResponseEntity.ok(dashboardService.getPopularReviews(param));
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/controller/api/DashboardApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/controller/api/DashboardApi.java
@@ -1,7 +1,8 @@
 package com.codeit.team4.deokhugam.dashboard.controller.api;
 
+import com.codeit.team4.deokhugam.dashboard.dto.DashboardSearchRequestParam;
 import com.codeit.team4.deokhugam.dashboard.dto.PopularBookResponse;
-import com.codeit.team4.deokhugam.dashboard.dto.PopularBookSearchRequestParam;
+import com.codeit.team4.deokhugam.dashboard.dto.PopularReviewResponse;
 import com.codeit.team4.deokhugam.global.error.ErrorResponse;
 import com.codeit.team4.deokhugam.global.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,7 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 
-@Tag(name = "인기 도서", description = "인기 도서 관련 API")
+@Tag(name = "대시보드", description = "대시보드 관련 API")
 public interface DashboardApi {
 
     @Operation(summary = "인기 도서 목록 조회", description = "기간별 인기 도서 목록을 조회합니다.")
@@ -25,6 +26,18 @@ public interface DashboardApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<PageResponse<PopularBookResponse>> getPopularBooks(
-            @ParameterObject PopularBookSearchRequestParam param
+            @ParameterObject DashboardSearchRequestParam param
+    );
+
+    @Operation(summary = "인기 리뷰 목록 조회", description = "기간별 인기 리뷰 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인기 리뷰 목록 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (랭킹 기간 오류, 정렬 방향 오류 등)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<PageResponse<PopularReviewResponse>> getPopularReviews(
+            @ParameterObject DashboardSearchRequestParam param
     );
 }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/dto/DashboardSearchRequestParam.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/dto/DashboardSearchRequestParam.java
@@ -9,8 +9,8 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import java.time.Instant;
 
-@Schema(description = "인기 도서 검색 요청")
-public record PopularBookSearchRequestParam(
+@Schema(description = "대시보드 검색 요청")
+public record DashboardSearchRequestParam(
 
         @Schema(description = "랭킹 기간", example = "DAILY", defaultValue = "DAILY")
         PeriodType period,
@@ -32,7 +32,7 @@ public record PopularBookSearchRequestParam(
 
     private static final int DEFAULT_LIMIT = 50;
 
-    public PopularBookSearchRequestParam {
+    public DashboardSearchRequestParam {
         if (period == null) {
             period = PeriodType.DAILY;
         }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/dto/PopularReviewResponse.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/dto/PopularReviewResponse.java
@@ -1,0 +1,58 @@
+package com.codeit.team4.deokhugam.dashboard.dto;
+
+import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Schema(description = "인기 리뷰 응답")
+public record PopularReviewResponse(
+
+        @Schema(description = "인기 리뷰 ID")
+        UUID id,
+
+        @Schema(description = "리뷰 ID")
+        UUID reviewId,
+
+        @Schema(description = "도서 ID")
+        UUID bookId,
+
+        @Schema(description = "도서 제목")
+        String bookTitle,
+
+        @Schema(description = "도서 썸네일 URL")
+        String bookThumbnailUrl,
+
+        @Schema(description = "사용자 ID")
+        UUID userId,
+
+        @Schema(description = "사용자 닉네임")
+        String userNickname,
+
+        @Schema(description = "리뷰 내용")
+        String reviewContent,
+
+        @Schema(description = "리뷰 평점")
+        int reviewRating,
+
+        @Schema(description = "랭킹 기간")
+        PeriodType period,
+
+        @Schema(description = "순위")
+        int rank,
+
+        @Schema(description = "점수")
+        BigDecimal score,
+
+        @Schema(description = "좋아요 수")
+        int likeCount,
+
+        @Schema(description = "댓글 수")
+        int commentCount,
+
+        @Schema(description = "생성 일시")
+        Instant createdAt
+) {
+
+}

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/entity/PopularReview.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/entity/PopularReview.java
@@ -34,6 +34,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PopularReview extends BaseEntity {
 
+    public static final BigDecimal LIKE_COUNT_WEIGHT = new BigDecimal("0.3");
+    public static final BigDecimal COMMENT_COUNT_WEIGHT = new BigDecimal("0.7");
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id")
     private Review review;
@@ -91,7 +94,6 @@ public class PopularReview extends BaseEntity {
             int reviewRating,
             PeriodType period,
             int rank,
-            BigDecimal score,
             int likeCount,
             int commentCount,
             LocalDate snapshotDate
@@ -106,10 +108,15 @@ public class PopularReview extends BaseEntity {
         this.reviewRating = reviewRating;
         this.period = period;
         this.rank = rank;
-        this.score = score;
+        this.score = calculateScore(likeCount, commentCount);
         this.likeCount = likeCount;
         this.commentCount = commentCount;
         this.snapshotDate = snapshotDate;
+    }
+
+    private BigDecimal calculateScore(int likeCount, int commentCount) {
+        return new BigDecimal(likeCount).multiply(LIKE_COUNT_WEIGHT)
+                .add(new BigDecimal(commentCount).multiply(COMMENT_COUNT_WEIGHT));
     }
 
     @Override

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/mapper/DashboardMapper.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/mapper/DashboardMapper.java
@@ -1,11 +1,15 @@
 package com.codeit.team4.deokhugam.dashboard.mapper;
 
 import com.codeit.team4.deokhugam.dashboard.dto.PopularBookResponse;
+import com.codeit.team4.deokhugam.dashboard.dto.PopularReviewResponse;
 import com.codeit.team4.deokhugam.dashboard.model.PopularBookViewModel;
+import com.codeit.team4.deokhugam.dashboard.model.PopularReviewViewModel;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
 public interface DashboardMapper {
 
     PopularBookResponse toPopularBookResponse(PopularBookViewModel model);
+
+    PopularReviewResponse toPopularReviewResponse(PopularReviewViewModel model);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/model/PopularBookSearchModel.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/model/PopularBookSearchModel.java
@@ -38,7 +38,8 @@ public record PopularBookSearchModel(
                 REVIEWS.BOOK_ID,
                 BOOKS.TITLE,
                 BOOKS.AUTHOR,
-                BOOKS.THUMBNAIL_URL
+                BOOKS.THUMBNAIL_URL,
+                BOOKS.CREATED_AT
         );
     }
 

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/model/PopularBookViewModel.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/model/PopularBookViewModel.java
@@ -22,7 +22,7 @@ public record PopularBookViewModel(
         int reviewCount,
         BigDecimal rating,
         Instant createdAt
-) {
+) implements RankedViewModel {
 
     public static List<Field<?>> toSelectedFields() {
         return List.of(

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/model/PopularReviewSearchModel.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/model/PopularReviewSearchModel.java
@@ -1,0 +1,54 @@
+package com.codeit.team4.deokhugam.dashboard.model;
+
+import static com.codeit.team4.deokhugam.jooq.tables.Books.BOOKS;
+import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
+import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
+
+import java.util.List;
+import java.util.UUID;
+import org.jooq.Field;
+import org.jooq.Record;
+
+public record PopularReviewSearchModel(
+        UUID reviewId,
+        UUID bookId,
+        String bookTitle,
+        String bookThumbnailUrl,
+        UUID userId,
+        String userNickname,
+        String reviewContent,
+        int reviewRating,
+        int likeCount,
+        int commentCount
+) {
+
+    public static List<Field<?>> toSelectedFields() {
+        return List.of(
+                REVIEWS.ID,
+                REVIEWS.BOOK_ID,
+                BOOKS.TITLE,
+                BOOKS.THUMBNAIL_URL,
+                REVIEWS.USER_ID,
+                USERS.NICKNAME,
+                REVIEWS.CONTENT,
+                REVIEWS.RATING,
+                REVIEWS.LIKE_COUNT,
+                REVIEWS.COMMENT_COUNT
+        );
+    }
+
+    public static PopularReviewSearchModel fromRecord(Record rec) {
+        return new PopularReviewSearchModel(
+                rec.get(REVIEWS.ID),
+                rec.get(REVIEWS.BOOK_ID),
+                rec.get(BOOKS.TITLE),
+                rec.get(BOOKS.THUMBNAIL_URL),
+                rec.get(REVIEWS.USER_ID),
+                rec.get(USERS.NICKNAME),
+                rec.get(REVIEWS.CONTENT),
+                rec.get(REVIEWS.RATING),
+                rec.get(REVIEWS.LIKE_COUNT),
+                rec.get(REVIEWS.COMMENT_COUNT)
+        );
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/model/PopularReviewViewModel.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/model/PopularReviewViewModel.java
@@ -1,0 +1,70 @@
+package com.codeit.team4.deokhugam.dashboard.model;
+
+import static com.codeit.team4.deokhugam.jooq.tables.PopularReviews.POPULAR_REVIEWS;
+
+import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.jooq.Field;
+import org.jooq.Record;
+
+public record PopularReviewViewModel(
+        UUID id,
+        UUID reviewId,
+        UUID bookId,
+        String bookTitle,
+        String bookThumbnailUrl,
+        UUID userId,
+        String userNickname,
+        String reviewContent,
+        int reviewRating,
+        PeriodType period,
+        int rank,
+        BigDecimal score,
+        int likeCount,
+        int commentCount,
+        Instant createdAt
+) implements RankedViewModel {
+
+    public static List<Field<?>> toSelectedFields() {
+        return List.of(
+                POPULAR_REVIEWS.ID,
+                POPULAR_REVIEWS.REVIEW_ID,
+                POPULAR_REVIEWS.BOOK_ID,
+                POPULAR_REVIEWS.BOOK_TITLE,
+                POPULAR_REVIEWS.BOOK_THUMBNAIL_URL,
+                POPULAR_REVIEWS.USER_ID,
+                POPULAR_REVIEWS.USER_NICKNAME,
+                POPULAR_REVIEWS.REVIEW_CONTENT,
+                POPULAR_REVIEWS.REVIEW_RATING,
+                POPULAR_REVIEWS.PERIOD,
+                POPULAR_REVIEWS.RANK,
+                POPULAR_REVIEWS.SCORE,
+                POPULAR_REVIEWS.LIKE_COUNT,
+                POPULAR_REVIEWS.COMMENT_COUNT,
+                POPULAR_REVIEWS.CREATED_AT
+        );
+    }
+
+    public static PopularReviewViewModel fromRecord(Record rec) {
+        return new PopularReviewViewModel(
+                rec.get(POPULAR_REVIEWS.ID),
+                rec.get(POPULAR_REVIEWS.REVIEW_ID),
+                rec.get(POPULAR_REVIEWS.BOOK_ID),
+                rec.get(POPULAR_REVIEWS.BOOK_TITLE),
+                rec.get(POPULAR_REVIEWS.BOOK_THUMBNAIL_URL),
+                rec.get(POPULAR_REVIEWS.USER_ID),
+                rec.get(POPULAR_REVIEWS.USER_NICKNAME),
+                rec.get(POPULAR_REVIEWS.REVIEW_CONTENT),
+                rec.get(POPULAR_REVIEWS.REVIEW_RATING),
+                PeriodType.valueOf(rec.get(POPULAR_REVIEWS.PERIOD)),
+                rec.get(POPULAR_REVIEWS.RANK),
+                rec.get(POPULAR_REVIEWS.SCORE),
+                rec.get(POPULAR_REVIEWS.LIKE_COUNT),
+                rec.get(POPULAR_REVIEWS.COMMENT_COUNT),
+                rec.get(POPULAR_REVIEWS.CREATED_AT).toInstant()
+        );
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/model/RankedViewModel.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/model/RankedViewModel.java
@@ -1,0 +1,10 @@
+package com.codeit.team4.deokhugam.dashboard.model;
+
+import java.time.Instant;
+
+public interface RankedViewModel {
+
+    int rank();
+
+    Instant createdAt();
+}

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/repository/PopularReviewRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/repository/PopularReviewRepository.java
@@ -1,9 +1,20 @@
 package com.codeit.team4.deokhugam.dashboard.repository;
 
+import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
 import com.codeit.team4.deokhugam.dashboard.entity.PopularReview;
+import java.time.LocalDate;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PopularReviewRepository extends JpaRepository<PopularReview, UUID> {
 
+    @Modifying
+    @Query("DELETE FROM PopularReview pr WHERE pr.period = :period AND pr.snapshotDate = :snapshotDate")
+    void deleteByPeriodAndSnapshotDate(
+            @Param("period") PeriodType period,
+            @Param("snapshotDate") LocalDate snapshotDate
+    );
 }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/scheduler/DashboardScheduler.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/scheduler/DashboardScheduler.java
@@ -28,6 +28,7 @@ public class DashboardScheduler {
         log.info("대시보드 배치 스케줄러 시작: snapshotDate={}", snapshotDate);
         try {
             dashboardBatchService.updatePopularBooks(snapshotDate);
+            dashboardBatchService.updatePopularReviews(snapshotDate);
             log.info("대시보드 배치 스케줄러 완료");
         } catch (Exception e) {
             log.error("대시보드 배치 스케줄러 실패", e);

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/scheduler/DashboardScheduler.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/scheduler/DashboardScheduler.java
@@ -28,10 +28,16 @@ public class DashboardScheduler {
         log.info("대시보드 배치 스케줄러 시작: snapshotDate={}", snapshotDate);
         try {
             dashboardBatchService.updatePopularBooks(snapshotDate);
-            dashboardBatchService.updatePopularReviews(snapshotDate);
-            log.info("대시보드 배치 스케줄러 완료");
         } catch (Exception e) {
-            log.error("대시보드 배치 스케줄러 실패", e);
+            log.error("인기 도서 배치 실패", e);
         }
+
+        try {
+            dashboardBatchService.updatePopularReviews(snapshotDate);
+        } catch (Exception e) {
+            log.error("인기 리뷰 배치 실패", e);
+        }
+
+        log.info("대시보드 배치 스케줄러 종료");
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchService.java
@@ -2,10 +2,17 @@ package com.codeit.team4.deokhugam.dashboard.service;
 
 import com.codeit.team4.deokhugam.book.entity.Book;
 import com.codeit.team4.deokhugam.book.service.BookService;
-import com.codeit.team4.deokhugam.dashboard.entity.PopularBook;
-import com.codeit.team4.deokhugam.dashboard.model.PopularBookSearchModel;
-import com.codeit.team4.deokhugam.dashboard.repository.PopularBookRepository;
 import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
+import com.codeit.team4.deokhugam.dashboard.entity.PopularBook;
+import com.codeit.team4.deokhugam.dashboard.entity.PopularReview;
+import com.codeit.team4.deokhugam.dashboard.model.PopularBookSearchModel;
+import com.codeit.team4.deokhugam.dashboard.model.PopularReviewSearchModel;
+import com.codeit.team4.deokhugam.dashboard.repository.PopularBookRepository;
+import com.codeit.team4.deokhugam.dashboard.repository.PopularReviewRepository;
+import com.codeit.team4.deokhugam.review.entity.Review;
+import com.codeit.team4.deokhugam.review.service.ReviewService;
+import com.codeit.team4.deokhugam.user.entity.User;
+import com.codeit.team4.deokhugam.user.service.UserService;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +31,11 @@ public class DashboardBatchService {
     private final PopularBookAggregator popularBookAggregator;
     private final BookService bookService;
 
+    private final PopularReviewRepository popularReviewRepository;
+    private final PopularReviewAggregator popularReviewAggregator;
+    private final ReviewService reviewService;
+    private final UserService userService;
+
     public void updatePopularBooks(LocalDate snapshotDate) {
         log.info("인기 도서 배치 시작: snapshotDate={}", snapshotDate);
 
@@ -32,6 +44,16 @@ public class DashboardBatchService {
         }
 
         log.info("인기 도서 배치 완료: snapshotDate={}", snapshotDate);
+    }
+
+    public void updatePopularReviews(LocalDate snapshotDate) {
+        log.info("인기 리뷰 배치 시작: snapshotDate={}", snapshotDate);
+
+        for (PeriodType period : PeriodType.values()) {
+            updatePopularReviewsByPeriod(period, snapshotDate);
+        }
+
+        log.info("인기 리뷰 배치 완료: snapshotDate={}", snapshotDate);
     }
 
     private void updatePopularBooksByPeriod(PeriodType period, LocalDate snapshotDate) {
@@ -59,5 +81,38 @@ public class DashboardBatchService {
 
         popularBookRepository.saveAll(popularBooks);
         log.info("인기 도서 {} 저장 완료: {}건", period, popularBooks.size());
+    }
+
+    private void updatePopularReviewsByPeriod(PeriodType period, LocalDate snapshotDate) {
+        popularReviewRepository.deleteByPeriodAndSnapshotDate(period, snapshotDate);
+
+        List<PopularReviewSearchModel> results = popularReviewAggregator.findTopReviews(period, snapshotDate);
+
+        List<PopularReview> popularReviews = new ArrayList<>();
+        for (int i = 0; i < results.size(); i++) {
+            PopularReviewSearchModel model = results.get(i);
+            Review review = reviewService.findById(model.reviewId());
+            Book book = bookService.findById(model.bookId());
+            User user = userService.findById(model.userId());
+
+            popularReviews.add(new PopularReview(
+                    review,
+                    book,
+                    user,
+                    model.bookTitle(),
+                    model.bookThumbnailUrl(),
+                    model.userNickname(),
+                    model.reviewContent(),
+                    model.reviewRating(),
+                    period,
+                    i + 1,
+                    model.likeCount(),
+                    model.commentCount(),
+                    snapshotDate
+            ));
+        }
+
+        popularReviewRepository.saveAll(popularReviews);
+        log.info("인기 리뷰 {} 저장 완료: {}건", period, popularReviews.size());
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacade.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacade.java
@@ -34,7 +34,7 @@ public class DashboardFacade {
 
         List<PopularBookViewModel> results = popularBookReader.findPopularBooks(param, latestSnapshotDate);
 
-        List<PopularBookViewModel> content = trimToLimit(results, param.limit());ㄷ
+        List<PopularBookViewModel> content = trimToLimit(results, param.limit());
         boolean hasNext = results.size() > param.limit();
 
         List<PopularBookResponse> responses = content.stream()

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacade.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacade.java
@@ -1,9 +1,12 @@
 package com.codeit.team4.deokhugam.dashboard.service;
 
+import com.codeit.team4.deokhugam.dashboard.dto.DashboardSearchRequestParam;
 import com.codeit.team4.deokhugam.dashboard.dto.PopularBookResponse;
-import com.codeit.team4.deokhugam.dashboard.dto.PopularBookSearchRequestParam;
+import com.codeit.team4.deokhugam.dashboard.dto.PopularReviewResponse;
 import com.codeit.team4.deokhugam.dashboard.mapper.DashboardMapper;
 import com.codeit.team4.deokhugam.dashboard.model.PopularBookViewModel;
+import com.codeit.team4.deokhugam.dashboard.model.PopularReviewViewModel;
+import com.codeit.team4.deokhugam.dashboard.model.RankedViewModel;
 import com.codeit.team4.deokhugam.global.response.PageResponse;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -17,12 +20,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class DashboardService {
+public class DashboardFacade {
 
     private final PopularBookReader popularBookReader;
+    private final PopularReviewReader popularReviewReader;
     private final DashboardMapper dashboardMapper;
 
-    public PageResponse<PopularBookResponse> getPopularBooks(PopularBookSearchRequestParam param) {
+    public PageResponse<PopularBookResponse> getPopularBooks(DashboardSearchRequestParam param) {
         LocalDate latestSnapshotDate = popularBookReader.findLatestSnapshotDate(param.period());
         List<PopularBookViewModel> results = popularBookReader.findPopularBooks(param, latestSnapshotDate);
 
@@ -43,18 +47,39 @@ public class DashboardService {
         );
     }
 
-    private List<PopularBookViewModel> trimToLimit(List<PopularBookViewModel> results, int limit) {
+    public PageResponse<PopularReviewResponse> getPopularReviews(DashboardSearchRequestParam param) {
+        LocalDate latestSnapshotDate = popularReviewReader.findLatestSnapshotDate(param.period());
+        List<PopularReviewViewModel> results = popularReviewReader.findPopularReviews(param, latestSnapshotDate);
+
+        List<PopularReviewViewModel> content = trimToLimit(results, param.limit());
+        boolean hasNext = results.size() > param.limit();
+
+        List<PopularReviewResponse> responses = content.stream()
+                .map(dashboardMapper::toPopularReviewResponse)
+                .toList();
+
+        return new PageResponse<>(
+                responses,
+                extractNextCursor(content, hasNext),
+                extractNextAfter(content, hasNext),
+                param.limit(),
+                null,
+                hasNext
+        );
+    }
+
+    private <T> List<T> trimToLimit(List<T> results, int limit) {
         return results.subList(0, Math.min(results.size(), limit));
     }
 
-    private String extractNextCursor(List<PopularBookViewModel> content, boolean hasNext) {
+    private <T extends RankedViewModel> String extractNextCursor(List<T> content, boolean hasNext) {
         if (!hasNext || content.isEmpty()) {
             return null;
         }
         return String.valueOf(content.get(content.size() - 1).rank());
     }
 
-    private Instant extractNextAfter(List<PopularBookViewModel> content, boolean hasNext) {
+    private <T extends RankedViewModel> Instant extractNextAfter(List<T> content, boolean hasNext) {
         if (!hasNext || content.isEmpty()) {
             return null;
         }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacade.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacade.java
@@ -28,9 +28,13 @@ public class DashboardFacade {
 
     public PageResponse<PopularBookResponse> getPopularBooks(DashboardSearchRequestParam param) {
         LocalDate latestSnapshotDate = popularBookReader.findLatestSnapshotDate(param.period());
+        if (latestSnapshotDate == null) {
+            return new PageResponse<>(List.of(), null, null, param.limit(), null, false);
+        }
+
         List<PopularBookViewModel> results = popularBookReader.findPopularBooks(param, latestSnapshotDate);
 
-        List<PopularBookViewModel> content = trimToLimit(results, param.limit());
+        List<PopularBookViewModel> content = trimToLimit(results, param.limit());ㄷ
         boolean hasNext = results.size() > param.limit();
 
         List<PopularBookResponse> responses = content.stream()
@@ -49,6 +53,10 @@ public class DashboardFacade {
 
     public PageResponse<PopularReviewResponse> getPopularReviews(DashboardSearchRequestParam param) {
         LocalDate latestSnapshotDate = popularReviewReader.findLatestSnapshotDate(param.period());
+        if (latestSnapshotDate == null) {
+            return new PageResponse<>(List.of(), null, null, param.limit(), null, false);
+        }
+
         List<PopularReviewViewModel> results = popularReviewReader.findPopularReviews(param, latestSnapshotDate);
 
         List<PopularReviewViewModel> content = trimToLimit(results, param.limit());

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/service/PopularReviewAggregator.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/service/PopularReviewAggregator.java
@@ -1,0 +1,37 @@
+package com.codeit.team4.deokhugam.dashboard.service;
+
+import static com.codeit.team4.deokhugam.jooq.tables.Books.BOOKS;
+import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
+import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
+
+import com.codeit.team4.deokhugam.dashboard.builder.PopularReviewAggregationQueryBuilder;
+import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
+import com.codeit.team4.deokhugam.dashboard.model.PopularReviewSearchModel;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PopularReviewAggregator {
+
+    private static final int POPULAR_REVIEW_LIMIT = 20;
+
+    private final DSLContext dsl;
+    private final PopularReviewAggregationQueryBuilder aggregationQueryBuilder;
+
+    public List<PopularReviewSearchModel> findTopReviews(PeriodType period, LocalDate snapshotDate) {
+        return dsl.select(PopularReviewSearchModel.toSelectedFields())
+                .from(REVIEWS)
+                .join(BOOKS).on(REVIEWS.BOOK_ID.eq(BOOKS.ID))
+                .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
+                .where(aggregationQueryBuilder.buildCondition(period, snapshotDate))
+                .orderBy(aggregationQueryBuilder.buildOrderBy())
+                .limit(POPULAR_REVIEW_LIMIT)
+                .fetch(PopularReviewSearchModel::fromRecord);
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/service/PopularReviewReader.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/service/PopularReviewReader.java
@@ -1,11 +1,11 @@
 package com.codeit.team4.deokhugam.dashboard.service;
 
-import static com.codeit.team4.deokhugam.jooq.tables.PopularBooks.POPULAR_BOOKS;
+import static com.codeit.team4.deokhugam.jooq.tables.PopularReviews.POPULAR_REVIEWS;
 
-import com.codeit.team4.deokhugam.dashboard.builder.PopularBookReadQueryBuilder;
+import com.codeit.team4.deokhugam.dashboard.builder.PopularReviewReadQueryBuilder;
 import com.codeit.team4.deokhugam.dashboard.dto.DashboardSearchRequestParam;
 import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
-import com.codeit.team4.deokhugam.dashboard.model.PopularBookViewModel;
+import com.codeit.team4.deokhugam.dashboard.model.PopularReviewViewModel;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -17,28 +17,28 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class PopularBookReader {
+public class PopularReviewReader {
 
     private final DSLContext dsl;
-    private final PopularBookReadQueryBuilder readQueryBuilder;
+    private final PopularReviewReadQueryBuilder readQueryBuilder;
 
     public LocalDate findLatestSnapshotDate(PeriodType period) {
-        return dsl.select(DSL.max(POPULAR_BOOKS.SNAPSHOT_DATE))
-                .from(POPULAR_BOOKS)
-                .where(POPULAR_BOOKS.PERIOD.eq(period.name()))
+        return dsl.select(DSL.max(POPULAR_REVIEWS.SNAPSHOT_DATE))
+                .from(POPULAR_REVIEWS)
+                .where(POPULAR_REVIEWS.PERIOD.eq(period.name()))
                 .fetchOneInto(LocalDate.class);
     }
 
-    public List<PopularBookViewModel> findPopularBooks(
+    public List<PopularReviewViewModel> findPopularReviews(
             DashboardSearchRequestParam param,
             LocalDate snapshotDate
     ) {
-        return dsl.select(PopularBookViewModel.toSelectedFields())
-                .from(POPULAR_BOOKS)
+        return dsl.select(PopularReviewViewModel.toSelectedFields())
+                .from(POPULAR_REVIEWS)
                 .where(readQueryBuilder.buildCondition(param, snapshotDate))
                 .orderBy(readQueryBuilder.buildOrderBy(param.direction()))
                 .limit(param.limit() + 1) // +1로 다음 페이지 존재 여부(hasNext) 판단
-                .fetch(PopularBookViewModel::fromRecord);
+                .fetch(PopularReviewViewModel::fromRecord);
     }
 
 }

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/builder/PopularBookAggregationQueryBuilderTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/builder/PopularBookAggregationQueryBuilderTest.java
@@ -177,9 +177,9 @@ class PopularBookAggregationQueryBuilderTest {
     class OrderByCondition {
 
         @Test
-        @DisplayName("정렬 조건 2개 생성 성공")
-        void buildOrderBy_hasTwoFields_success() {
-            assertThat(queryBuilder.buildOrderBy()).hasSize(2);
+        @DisplayName("정렬 조건 3개 생성 성공")
+        void buildOrderBy_hasThreeFields_success() {
+            assertThat(queryBuilder.buildOrderBy()).hasSize(3);
         }
 
         @Test

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/builder/PopularReviewAggregationQueryBuilderTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/builder/PopularReviewAggregationQueryBuilderTest.java
@@ -134,9 +134,9 @@ class PopularReviewAggregationQueryBuilderTest {
     class OrderByCondition {
 
         @Test
-        @DisplayName("정렬 조건 2개 생성 성공")
-        void buildOrderBy_hasTwoFields_success() {
-            assertThat(queryBuilder.buildOrderBy()).hasSize(2);
+        @DisplayName("정렬 조건 3개 생성 성공")
+        void buildOrderBy_hasThreeFields_success() {
+            assertThat(queryBuilder.buildOrderBy()).hasSize(3);
         }
 
         @Test

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/builder/PopularReviewAggregationQueryBuilderTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/builder/PopularReviewAggregationQueryBuilderTest.java
@@ -2,13 +2,13 @@ package com.codeit.team4.deokhugam.dashboard.builder;
 
 import static com.codeit.team4.deokhugam.jooq.tables.Books.BOOKS;
 import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
+import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.codeit.team4.deokhugam.book.entity.Book;
 import com.codeit.team4.deokhugam.book.repository.BookRepository;
 import com.codeit.team4.deokhugam.config.TestContainerConfig;
 import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
-import com.codeit.team4.deokhugam.dashboard.model.PopularBookSearchModel;
 import com.codeit.team4.deokhugam.review.entity.Review;
 import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
 import com.codeit.team4.deokhugam.user.entity.User;
@@ -35,10 +35,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Import(TestContainerConfig.class)
 @ActiveProfiles("test")
 @Transactional
-class PopularBookAggregationQueryBuilderTest {
+class PopularReviewAggregationQueryBuilderTest {
 
     @Autowired
-    private PopularBookAggregationQueryBuilder queryBuilder;
+    private PopularReviewAggregationQueryBuilder queryBuilder;
 
     @Autowired
     private DSLContext dsl;
@@ -68,6 +68,7 @@ class PopularBookAggregationQueryBuilderTest {
         return dsl.selectCount()
                 .from(REVIEWS)
                 .join(BOOKS).on(REVIEWS.BOOK_ID.eq(BOOKS.ID))
+                .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
                 .where(condition)
                 .fetchOne(0, int.class);
     }
@@ -88,39 +89,6 @@ class PopularBookAggregationQueryBuilderTest {
         }
 
         @Test
-        @DisplayName("WEEKLY 고정 기간 조건 생성 성공")
-        void buildCondition_weekly_success() {
-            reviewRepository.saveAndFlush(new Review(book, user, "좋은 책입니다", 5));
-
-            LocalDate today = LocalDate.now(ZoneId.of(zone));
-            Condition condition = queryBuilder.buildCondition(PeriodType.WEEKLY, today);
-
-            assertThat(countWithCondition(condition)).isEqualTo(1);
-        }
-
-        @Test
-        @DisplayName("MONTHLY 고정 기간 조건 생성 성공")
-        void buildCondition_monthly_success() {
-            reviewRepository.saveAndFlush(new Review(book, user, "좋은 책입니다", 5));
-
-            LocalDate today = LocalDate.now(ZoneId.of(zone));
-            Condition condition = queryBuilder.buildCondition(PeriodType.MONTHLY, today);
-
-            assertThat(countWithCondition(condition)).isEqualTo(1);
-        }
-
-        @Test
-        @DisplayName("ALL_TIME 조건 생성 성공")
-        void buildCondition_allTime_success() {
-            reviewRepository.saveAndFlush(new Review(book, user, "좋은 책입니다", 5));
-
-            LocalDate today = LocalDate.now(ZoneId.of(zone));
-            Condition condition = queryBuilder.buildCondition(PeriodType.ALL_TIME, today);
-
-            assertThat(countWithCondition(condition)).isEqualTo(1);
-        }
-
-        @Test
         @DisplayName("ALL_TIME은 과거 리뷰도 포함 성공")
         void buildCondition_allTime_includesPastReviews_success() {
             reviewRepository.saveAndFlush(new Review(book, user, "좋은 책입니다", 5));
@@ -132,19 +100,6 @@ class PopularBookAggregationQueryBuilderTest {
 
             assertThat(countWithCondition(dailyCondition)).isZero();
             assertThat(countWithCondition(allTimeCondition)).isEqualTo(1);
-        }
-
-        @Test
-        @DisplayName("소프트 삭제된 도서 제외 성공")
-        void buildCondition_excludesSoftDeletedBook_success() {
-            reviewRepository.saveAndFlush(new Review(book, user, "좋은 책입니다", 5));
-            book.softDelete(Instant.now());
-            bookRepository.saveAndFlush(book);
-
-            LocalDate today = LocalDate.now(ZoneId.of(zone));
-            Condition condition = queryBuilder.buildCondition(PeriodType.ALL_TIME, today);
-
-            assertThat(countWithCondition(condition)).isZero();
         }
 
         @Test
@@ -161,12 +116,14 @@ class PopularBookAggregationQueryBuilderTest {
         }
 
         @Test
-        @DisplayName("기간 외 리뷰 제외 성공")
-        void buildCondition_excludesOutOfRange_success() {
+        @DisplayName("소프트 삭제된 도서 제외 성공")
+        void buildCondition_excludesSoftDeletedBook_success() {
             reviewRepository.saveAndFlush(new Review(book, user, "좋은 책입니다", 5));
+            book.softDelete(Instant.now());
+            bookRepository.saveAndFlush(book);
 
-            LocalDate pastDate = LocalDate.of(2020, 1, 1);
-            Condition condition = queryBuilder.buildCondition(PeriodType.DAILY, pastDate);
+            LocalDate today = LocalDate.now(ZoneId.of(zone));
+            Condition condition = queryBuilder.buildCondition(PeriodType.ALL_TIME, today);
 
             assertThat(countWithCondition(condition)).isZero();
         }
@@ -183,7 +140,7 @@ class PopularBookAggregationQueryBuilderTest {
         }
 
         @Test
-        @DisplayName("동점 도서 정렬 순서 일관성 성공")
+        @DisplayName("동점 리뷰 정렬 순서 일관성 성공")
         void buildOrderBy_tieBreaker_success() {
             Book otherBook = bookRepository.saveAndFlush(
                     new Book("다른 책", "다른 저자", "설명", "출판사", LocalDate.of(2024, 2, 1), "1234567891")
@@ -194,50 +151,51 @@ class PopularBookAggregationQueryBuilderTest {
             LocalDate today = LocalDate.now(ZoneId.of(zone));
             Condition condition = queryBuilder.buildCondition(PeriodType.ALL_TIME, today);
 
-            List<UUID> firstResult = dsl.select(REVIEWS.BOOK_ID)
+            List<UUID> firstResult = dsl.select(REVIEWS.ID)
                     .from(REVIEWS)
                     .join(BOOKS).on(REVIEWS.BOOK_ID.eq(BOOKS.ID))
+                    .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
                     .where(condition)
-                    .groupBy(PopularBookSearchModel.toGroupByFields())
                     .orderBy(queryBuilder.buildOrderBy())
-                    .fetch(REVIEWS.BOOK_ID);
+                    .fetch(REVIEWS.ID);
 
-            List<UUID> secondResult = dsl.select(REVIEWS.BOOK_ID)
+            List<UUID> secondResult = dsl.select(REVIEWS.ID)
                     .from(REVIEWS)
                     .join(BOOKS).on(REVIEWS.BOOK_ID.eq(BOOKS.ID))
+                    .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
                     .where(condition)
-                    .groupBy(PopularBookSearchModel.toGroupByFields())
                     .orderBy(queryBuilder.buildOrderBy())
-                    .fetch(REVIEWS.BOOK_ID);
+                    .fetch(REVIEWS.ID);
 
             assertThat(firstResult).hasSize(2);
             assertThat(firstResult).isEqualTo(secondResult);
         }
 
         @Test
-        @DisplayName("동점 시 먼저 등록한 도서가 우선 성공")
-        void buildOrderBy_tieBreaker_earlierBookFirst_success() {
-            // book은 setUp에서 publishedDate=2024-01-01로 먼저 생성됨
-            Book laterBook = bookRepository.saveAndFlush(
-                    new Book("나중 책", "저자", "설명", "출판사", LocalDate.of(2024, 6, 1), "1234567891")
+        @DisplayName("동점 시 먼저 작성한 리뷰가 우선 성공")
+        void buildOrderBy_tieBreaker_earlierReviewFirst_success() {
+            Review earlierReview = reviewRepository.saveAndFlush(new Review(book, user, "먼저 쓴 리뷰", 5));
+
+            Book otherBook = bookRepository.saveAndFlush(
+                    new Book("다른 책", "다른 저자", "설명", "출판사", LocalDate.of(2024, 2, 1), "1234567891")
             );
-            reviewRepository.saveAndFlush(new Review(book, user, "좋은 책입니다", 5));
-            reviewRepository.saveAndFlush(new Review(laterBook, user, "좋은 책입니다", 5));
+            User otherUser = userRepository.saveAndFlush(new User("other@test.com", "다른사람", "password123"));
+            Review laterReview = reviewRepository.saveAndFlush(new Review(otherBook, otherUser, "나중에 쓴 리뷰", 5));
 
             LocalDate today = LocalDate.now(ZoneId.of(zone));
             Condition condition = queryBuilder.buildCondition(PeriodType.ALL_TIME, today);
 
-            List<UUID> result = dsl.select(REVIEWS.BOOK_ID)
+            List<UUID> result = dsl.select(REVIEWS.ID)
                     .from(REVIEWS)
                     .join(BOOKS).on(REVIEWS.BOOK_ID.eq(BOOKS.ID))
+                    .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
                     .where(condition)
-                    .groupBy(PopularBookSearchModel.toGroupByFields())
                     .orderBy(queryBuilder.buildOrderBy())
-                    .fetch(REVIEWS.BOOK_ID);
+                    .fetch(REVIEWS.ID);
 
             assertThat(result).hasSize(2);
-            assertThat(result.get(0)).isEqualTo(book.getId());
-            assertThat(result.get(1)).isEqualTo(laterBook.getId());
+            assertThat(result.get(0)).isEqualTo(earlierReview.getId());
+            assertThat(result.get(1)).isEqualTo(laterReview.getId());
         }
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/controller/DashboardControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/controller/DashboardControllerTest.java
@@ -8,9 +8,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.codeit.team4.deokhugam.dashboard.dto.PopularBookResponse;
-import com.codeit.team4.deokhugam.dashboard.dto.PopularBookSearchRequestParam;
+import com.codeit.team4.deokhugam.dashboard.dto.DashboardSearchRequestParam;
 import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
-import com.codeit.team4.deokhugam.dashboard.service.DashboardService;
+import com.codeit.team4.deokhugam.dashboard.service.DashboardFacade;
 import com.codeit.team4.deokhugam.global.config.AppProperties;
 import com.codeit.team4.deokhugam.global.response.PageResponse;
 import com.codeit.team4.deokhugam.user.service.UserService;
@@ -36,7 +36,7 @@ class DashboardControllerTest {
     private MockMvc mockMvc;
 
     @MockitoBean
-    private DashboardService dashboardService;
+    private DashboardFacade dashboardService;
 
     @MockitoBean
     private UserService userService;
@@ -64,7 +64,7 @@ class DashboardControllerTest {
                 List.of(createResponse(1), createResponse(2)),
                 null, null, 50, null, false
         );
-        given(dashboardService.getPopularBooks(any(PopularBookSearchRequestParam.class)))
+        given(dashboardService.getPopularBooks(any(DashboardSearchRequestParam.class)))
                 .willReturn(response);
 
         mockMvc.perform(get("/api/books/popular")
@@ -85,7 +85,7 @@ class DashboardControllerTest {
         PageResponse<PopularBookResponse> response = new PageResponse<>(
                 List.of(), null, null, 50, null, false
         );
-        given(dashboardService.getPopularBooks(any(PopularBookSearchRequestParam.class)))
+        given(dashboardService.getPopularBooks(any(DashboardSearchRequestParam.class)))
                 .willReturn(response);
 
         mockMvc.perform(get("/api/books/popular")

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/entity/PopularReviewTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/entity/PopularReviewTest.java
@@ -1,0 +1,42 @@
+package com.codeit.team4.deokhugam.dashboard.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PopularReviewTest {
+
+    @Test
+    @DisplayName("score 계산 성공")
+    void calculateScore_success() {
+        PopularReview popularReview = new PopularReview(
+                null, null, null,
+                "책 제목", null, "닉네임",
+                "리뷰 내용", 5,
+                PeriodType.DAILY, 1,
+                10, 5,
+                LocalDate.of(2026, 4, 23)
+        );
+
+        // score = 10 * 0.3 + 5 * 0.7 = 3.0 + 3.5 = 6.5
+        assertThat(popularReview.getScore()).isEqualByComparingTo(new BigDecimal("6.5"));
+    }
+
+    @Test
+    @DisplayName("좋아요/댓글 0건일 때 score 계산 성공")
+    void calculateScore_zero_success() {
+        PopularReview popularReview = new PopularReview(
+                null, null, null,
+                "책 제목", null, "닉네임",
+                "리뷰 내용", 3,
+                PeriodType.WEEKLY, 1,
+                0, 0,
+                LocalDate.of(2026, 4, 23)
+        );
+
+        assertThat(popularReview.getScore()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+}

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchServiceTest.java
@@ -7,7 +7,9 @@ import com.codeit.team4.deokhugam.book.repository.BookRepository;
 import com.codeit.team4.deokhugam.config.TestContainerConfig;
 import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
 import com.codeit.team4.deokhugam.dashboard.entity.PopularBook;
+import com.codeit.team4.deokhugam.dashboard.entity.PopularReview;
 import com.codeit.team4.deokhugam.dashboard.repository.PopularBookRepository;
+import com.codeit.team4.deokhugam.dashboard.repository.PopularReviewRepository;
 import com.codeit.team4.deokhugam.review.entity.Review;
 import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
 import com.codeit.team4.deokhugam.user.entity.User;
@@ -37,6 +39,9 @@ class DashboardBatchServiceTest {
 
     @Autowired
     private PopularBookRepository popularBookRepository;
+
+    @Autowired
+    private PopularReviewRepository popularReviewRepository;
 
     @Autowired
     private ReviewRepository reviewRepository;
@@ -144,6 +149,92 @@ class DashboardBatchServiceTest {
             for (PeriodType period : PeriodType.values()) {
                 List<PopularBook> byPeriod = popularBookRepository.findAll().stream()
                         .filter(pb -> pb.getPeriod() == period && pb.getSnapshotDate().equals(today))
+                        .toList();
+                assertThat(byPeriod).isNotEmpty();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("인기 리뷰 배치")
+    class UpdatePopularReviews {
+
+        @Test
+        @DisplayName("인기 리뷰 배치 실행 성공")
+        void updatePopularReviews_success() {
+            Book book1 = createBook("책1", "1111111111");
+            Book book2 = createBook("책2", "2222222222");
+            reviewRepository.saveAndFlush(new Review(book1, user, "좋아요", 5));
+            reviewRepository.saveAndFlush(new Review(book2, user, "괜찮아요", 3));
+
+            LocalDate today = LocalDate.now(ZoneId.of(zone));
+            dashboardBatchService.updatePopularReviews(today);
+
+            List<PopularReview> results = popularReviewRepository.findAll();
+            assertThat(results).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("LIMIT 20 적용 성공")
+        void updatePopularReviews_limit_success() {
+            for (int i = 0; i < 25; i++) {
+                Book book = createBook("책" + i, "100000000" + String.format("%02d", i));
+                reviewRepository.saveAndFlush(new Review(book, user, "리뷰" + i, (i % 5) + 1));
+            }
+
+            LocalDate today = LocalDate.now(ZoneId.of(zone));
+            dashboardBatchService.updatePopularReviews(today);
+
+            for (PeriodType period : PeriodType.values()) {
+                List<PopularReview> byPeriod = popularReviewRepository.findAll().stream()
+                        .filter(pr -> pr.getPeriod() == period && pr.getSnapshotDate().equals(today))
+                        .toList();
+                assertThat(byPeriod).hasSizeLessThanOrEqualTo(20);
+            }
+        }
+
+        @Test
+        @DisplayName("ranking 순서 부여 성공")
+        void updatePopularReviews_ranking_success() {
+            Book book1 = createBook("책1", "1111111111");
+            Book book2 = createBook("책2", "2222222222");
+            Review review1 = reviewRepository.saveAndFlush(new Review(book1, user, "인기 리뷰", 5));
+            Review review2 = reviewRepository.saveAndFlush(new Review(book2, user, "보통 리뷰", 1));
+
+            LocalDate today = LocalDate.now(ZoneId.of(zone));
+            dashboardBatchService.updatePopularReviews(today);
+
+            List<PopularReview> dailyReviews = popularReviewRepository.findAll().stream()
+                    .filter(pr -> pr.getPeriod() == PeriodType.DAILY && pr.getSnapshotDate().equals(today))
+                    .sorted((a, b) -> Integer.compare(a.getRank(), b.getRank()))
+                    .toList();
+
+            assertThat(dailyReviews).hasSize(2);
+            assertThat(dailyReviews.get(0).getRank()).isEqualTo(1);
+            assertThat(dailyReviews.get(1).getRank()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("리뷰 없을 때 빈 결과 반환 성공")
+        void updatePopularReviews_noReviews_success() {
+            LocalDate today = LocalDate.now(ZoneId.of(zone));
+            dashboardBatchService.updatePopularReviews(today);
+
+            assertThat(popularReviewRepository.findAll()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("모든 PeriodType에 대해 배치 실행 성공")
+        void updatePopularReviews_allPeriods_success() {
+            Book book = createBook("책1", "1111111111");
+            reviewRepository.saveAndFlush(new Review(book, user, "좋아요", 5));
+
+            LocalDate today = LocalDate.now(ZoneId.of(zone));
+            dashboardBatchService.updatePopularReviews(today);
+
+            for (PeriodType period : PeriodType.values()) {
+                List<PopularReview> byPeriod = popularReviewRepository.findAll().stream()
+                        .filter(pr -> pr.getPeriod() == period && pr.getSnapshotDate().equals(today))
                         .toList();
                 assertThat(byPeriod).isNotEmpty();
             }

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchServiceTest.java
@@ -14,6 +14,8 @@ import com.codeit.team4.deokhugam.review.entity.Review;
 import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
 import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.repository.UserRepository;
+import org.jooq.DSLContext;
+import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
@@ -51,6 +53,9 @@ class DashboardBatchServiceTest {
 
     @Autowired
     private BookRepository bookRepository;
+
+    @Autowired
+    private DSLContext dsl;
 
     @Value("${dashboard.batch.zone}")
     private String zone;
@@ -189,17 +194,24 @@ class DashboardBatchServiceTest {
                 List<PopularReview> byPeriod = popularReviewRepository.findAll().stream()
                         .filter(pr -> pr.getPeriod() == period && pr.getSnapshotDate().equals(today))
                         .toList();
-                assertThat(byPeriod).hasSizeLessThanOrEqualTo(20);
+                assertThat(byPeriod).hasSize(20);
             }
         }
 
         @Test
-        @DisplayName("ranking 순서 부여 성공")
+        @DisplayName("score 기반 ranking 순서 부여 성공")
         void updatePopularReviews_ranking_success() {
             Book book1 = createBook("책1", "1111111111");
             Book book2 = createBook("책2", "2222222222");
             Review review1 = reviewRepository.saveAndFlush(new Review(book1, user, "인기 리뷰", 5));
-            Review review2 = reviewRepository.saveAndFlush(new Review(book2, user, "보통 리뷰", 1));
+            Review review2 = reviewRepository.saveAndFlush(new Review(book2, user, "보통 리뷰", 3));
+
+            // review1: like=10, comment=5 → score = 10*0.3 + 5*0.7 = 6.5
+            // review2: like=2, comment=1 → score = 2*0.3 + 1*0.7 = 1.3
+            dsl.update(REVIEWS).set(REVIEWS.LIKE_COUNT, 10).set(REVIEWS.COMMENT_COUNT, 5)
+                    .where(REVIEWS.ID.eq(review1.getId())).execute();
+            dsl.update(REVIEWS).set(REVIEWS.LIKE_COUNT, 2).set(REVIEWS.COMMENT_COUNT, 1)
+                    .where(REVIEWS.ID.eq(review2.getId())).execute();
 
             LocalDate today = LocalDate.now(ZoneId.of(zone));
             dashboardBatchService.updatePopularReviews(today);
@@ -212,6 +224,7 @@ class DashboardBatchServiceTest {
             assertThat(dailyReviews).hasSize(2);
             assertThat(dailyReviews.get(0).getRank()).isEqualTo(1);
             assertThat(dailyReviews.get(1).getRank()).isEqualTo(2);
+            assertThat(dailyReviews.get(0).getScore()).isGreaterThan(dailyReviews.get(1).getScore());
         }
 
         @Test

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacadeTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacadeTest.java
@@ -226,6 +226,56 @@ class DashboardFacadeTest {
         }
 
         @Test
+        @DisplayName("DESC 정렬 조회 성공")
+        void getPopularReviews_desc_success() {
+            LocalDate snapshotDate = LocalDate.now(ZoneId.of(zone));
+            Book book1 = createBook("책1", "1111111111");
+            Book book2 = createBook("책2", "2222222222");
+            reviewRepository.saveAndFlush(new Review(book1, user, "좋아요", 5));
+            reviewRepository.saveAndFlush(new Review(book2, user, "괜찮아요", 3));
+            runBatch(snapshotDate);
+
+            DashboardSearchRequestParam param = new DashboardSearchRequestParam(
+                    PeriodType.DAILY, SortDirection.DESC, null, null, 50
+            );
+
+            PageResponse<PopularReviewResponse> result = dashboardService.getPopularReviews(param);
+
+            assertThat(result.content()).hasSize(2);
+            assertThat(result.content().get(0).rank()).isEqualTo(2);
+            assertThat(result.content().get(1).rank()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("커서 페이지네이션 성공")
+        void getPopularReviews_cursor_success() {
+            LocalDate snapshotDate = LocalDate.now(ZoneId.of(zone));
+            for (int i = 0; i < 3; i++) {
+                Book book = createBook("책" + i, "100000000" + i);
+                reviewRepository.saveAndFlush(new Review(book, user, "리뷰" + i, 5 - i));
+            }
+            runBatch(snapshotDate);
+
+            DashboardSearchRequestParam firstPage = new DashboardSearchRequestParam(
+                    PeriodType.DAILY, SortDirection.ASC, null, null, 2
+            );
+            PageResponse<PopularReviewResponse> firstResult = dashboardService.getPopularReviews(firstPage);
+
+            assertThat(firstResult.content()).hasSize(2);
+            assertThat(firstResult.hasNext()).isTrue();
+            assertThat(firstResult.nextCursor()).isNotNull();
+
+            DashboardSearchRequestParam secondPage = new DashboardSearchRequestParam(
+                    PeriodType.DAILY, SortDirection.ASC,
+                    firstResult.nextCursor(), firstResult.nextAfter(), 2
+            );
+            PageResponse<PopularReviewResponse> secondResult = dashboardService.getPopularReviews(secondPage);
+
+            assertThat(secondResult.content()).hasSize(1);
+            assertThat(secondResult.hasNext()).isFalse();
+        }
+
+        @Test
         @DisplayName("잘못된 cursor로 조회 실패")
         void getPopularReviews_invalidCursor_fail() {
             LocalDate snapshotDate = LocalDate.now(ZoneId.of(zone));

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacadeTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacadeTest.java
@@ -8,7 +8,8 @@ import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.book.repository.BookRepository;
 import com.codeit.team4.deokhugam.config.TestContainerConfig;
 import com.codeit.team4.deokhugam.dashboard.dto.PopularBookResponse;
-import com.codeit.team4.deokhugam.dashboard.dto.PopularBookSearchRequestParam;
+import com.codeit.team4.deokhugam.dashboard.dto.PopularReviewResponse;
+import com.codeit.team4.deokhugam.dashboard.dto.DashboardSearchRequestParam;
 import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
 import com.codeit.team4.deokhugam.global.response.PageResponse;
 import com.codeit.team4.deokhugam.global.response.SortDirection;
@@ -33,10 +34,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Import(TestContainerConfig.class)
 @ActiveProfiles("test")
 @Transactional
-class DashboardServiceTest {
+class DashboardFacadeTest {
 
     @Autowired
-    private DashboardService dashboardService;
+    private DashboardFacade dashboardService;
 
     @Autowired
     private DashboardBatchService dashboardBatchService;
@@ -68,6 +69,7 @@ class DashboardServiceTest {
 
     private void runBatch(LocalDate snapshotDate) {
         dashboardBatchService.updatePopularBooks(snapshotDate);
+        dashboardBatchService.updatePopularReviews(snapshotDate);
     }
 
     @Nested
@@ -84,7 +86,7 @@ class DashboardServiceTest {
             reviewRepository.saveAndFlush(new Review(book2, user, "괜찮아요", 3));
             runBatch(snapshotDate);
 
-            PopularBookSearchRequestParam param = new PopularBookSearchRequestParam(
+            DashboardSearchRequestParam param = new DashboardSearchRequestParam(
                     PeriodType.DAILY, SortDirection.ASC, null, null, 50
             );
 
@@ -107,7 +109,7 @@ class DashboardServiceTest {
             reviewRepository.saveAndFlush(new Review(book2, user, "괜찮아요", 3));
             runBatch(snapshotDate);
 
-            PopularBookSearchRequestParam param = new PopularBookSearchRequestParam(
+            DashboardSearchRequestParam param = new DashboardSearchRequestParam(
                     PeriodType.DAILY, SortDirection.DESC, null, null, 50
             );
 
@@ -129,7 +131,7 @@ class DashboardServiceTest {
             runBatch(snapshotDate);
 
             // 1페이지
-            PopularBookSearchRequestParam firstPage = new PopularBookSearchRequestParam(
+            DashboardSearchRequestParam firstPage = new DashboardSearchRequestParam(
                     PeriodType.DAILY, SortDirection.ASC, null, null, 2
             );
             PageResponse<PopularBookResponse> firstResult = dashboardService.getPopularBooks(firstPage);
@@ -139,7 +141,7 @@ class DashboardServiceTest {
             assertThat(firstResult.nextCursor()).isNotNull();
 
             // 2페이지
-            PopularBookSearchRequestParam secondPage = new PopularBookSearchRequestParam(
+            DashboardSearchRequestParam secondPage = new DashboardSearchRequestParam(
                     PeriodType.DAILY, SortDirection.ASC,
                     firstResult.nextCursor(), firstResult.nextAfter(), 2
             );
@@ -154,7 +156,7 @@ class DashboardServiceTest {
         void getPopularBooks_empty_success() {
             runBatch(LocalDate.now(ZoneId.of(zone)));
 
-            PopularBookSearchRequestParam param = new PopularBookSearchRequestParam(
+            DashboardSearchRequestParam param = new DashboardSearchRequestParam(
                     PeriodType.DAILY, SortDirection.ASC, null, null, 50
             );
 
@@ -172,11 +174,70 @@ class DashboardServiceTest {
             reviewRepository.saveAndFlush(new Review(book, user, "좋아요", 5));
             runBatch(snapshotDate);
 
-            PopularBookSearchRequestParam param = new PopularBookSearchRequestParam(
+            DashboardSearchRequestParam param = new DashboardSearchRequestParam(
                     PeriodType.DAILY, SortDirection.ASC, "invalid", null, 50
             );
 
             assertThatThrownBy(() -> dashboardService.getPopularBooks(param))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("인기 리뷰 조회")
+    class GetPopularReviews {
+
+        @Test
+        @DisplayName("인기 리뷰 조회 성공")
+        void getPopularReviews_success() {
+            LocalDate snapshotDate = LocalDate.now(ZoneId.of(zone));
+            Book book1 = createBook("책1", "1111111111");
+            Book book2 = createBook("책2", "2222222222");
+            reviewRepository.saveAndFlush(new Review(book1, user, "좋아요", 5));
+            reviewRepository.saveAndFlush(new Review(book2, user, "괜찮아요", 3));
+            runBatch(snapshotDate);
+
+            DashboardSearchRequestParam param = new DashboardSearchRequestParam(
+                    PeriodType.DAILY, SortDirection.ASC, null, null, 50
+            );
+
+            PageResponse<PopularReviewResponse> result = dashboardService.getPopularReviews(param);
+
+            assertThat(result.content()).hasSize(2);
+            assertThat(result.content().get(0).rank()).isEqualTo(1);
+            assertThat(result.content().get(1).rank()).isEqualTo(2);
+            assertThat(result.hasNext()).isFalse();
+            assertThat(result.totalElements()).isNull();
+        }
+
+        @Test
+        @DisplayName("데이터 없을 때 빈 결과 반환 성공")
+        void getPopularReviews_empty_success() {
+            runBatch(LocalDate.now(ZoneId.of(zone)));
+
+            DashboardSearchRequestParam param = new DashboardSearchRequestParam(
+                    PeriodType.DAILY, SortDirection.ASC, null, null, 50
+            );
+
+            PageResponse<PopularReviewResponse> result = dashboardService.getPopularReviews(param);
+
+            assertThat(result.content()).isEmpty();
+            assertThat(result.hasNext()).isFalse();
+        }
+
+        @Test
+        @DisplayName("잘못된 cursor로 조회 실패")
+        void getPopularReviews_invalidCursor_fail() {
+            LocalDate snapshotDate = LocalDate.now(ZoneId.of(zone));
+            Book book = createBook("책1", "1111111111");
+            reviewRepository.saveAndFlush(new Review(book, user, "좋아요", 5));
+            runBatch(snapshotDate);
+
+            DashboardSearchRequestParam param = new DashboardSearchRequestParam(
+                    PeriodType.DAILY, SortDirection.ASC, "invalid", null, 50
+            );
+
+            assertThatThrownBy(() -> dashboardService.getPopularReviews(param))
                     .isInstanceOf(BusinessException.class);
         }
     }

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/service/PopularBookReaderTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/service/PopularBookReaderTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.codeit.team4.deokhugam.book.entity.Book;
 import com.codeit.team4.deokhugam.book.repository.BookRepository;
 import com.codeit.team4.deokhugam.config.TestContainerConfig;
-import com.codeit.team4.deokhugam.dashboard.dto.PopularBookSearchRequestParam;
+import com.codeit.team4.deokhugam.dashboard.dto.DashboardSearchRequestParam;
 import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
 import com.codeit.team4.deokhugam.dashboard.model.PopularBookViewModel;
 import com.codeit.team4.deokhugam.global.response.SortDirection;
@@ -108,7 +108,7 @@ class PopularBookReaderTest {
             reviewRepository.saveAndFlush(new Review(book2, user, "괜찮아요", 3));
             runBatch(snapshotDate);
 
-            PopularBookSearchRequestParam param = new PopularBookSearchRequestParam(
+            DashboardSearchRequestParam param = new DashboardSearchRequestParam(
                     PeriodType.DAILY, SortDirection.ASC, null, null, 50
             );
 
@@ -129,7 +129,7 @@ class PopularBookReaderTest {
             runBatch(snapshotDate);
 
             // 1페이지
-            PopularBookSearchRequestParam firstPage = new PopularBookSearchRequestParam(
+            DashboardSearchRequestParam firstPage = new DashboardSearchRequestParam(
                     PeriodType.DAILY, SortDirection.ASC, null, null, 2
             );
             List<PopularBookViewModel> firstResults = popularBookReader.findPopularBooks(firstPage, snapshotDate);
@@ -137,7 +137,7 @@ class PopularBookReaderTest {
             assertThat(firstResults).hasSize(3); // limit+1
 
             // 2페이지
-            PopularBookSearchRequestParam secondPage = new PopularBookSearchRequestParam(
+            DashboardSearchRequestParam secondPage = new DashboardSearchRequestParam(
                     PeriodType.DAILY, SortDirection.ASC,
                     String.valueOf(firstResults.get(1).rank()), null, 2
             );


### PR DESCRIPTION
## 관련 이슈
- closes #40

## 작업 내용
- 인기 리뷰 대시보드 배치 + 조회 API 구현
- 프론트에서 인기 리뷰 호출 시 DESC 로 요청되어 인기 리뷰 순위가 반대로 보이는 문제 있음 (프론트 수정 해주신다고 함)

## 변경 사항
 인기 리뷰 배치                                                                                                                                                                                          

  - DashboardBatchService — updatePopularReviews 추가 (기간별 인기 리뷰 집계)                                                                                                                               
  - PopularReviewAggregator + PopularReviewAggregationQueryBuilder — jOOQ 기반 집계 (score = likeCount * 0.3 + commentCount * 0.7, 동점 시 먼저 작성한 리뷰 우선)
  - PopularReview 엔티티에서 score 자체 계산, LIMIT 20 적용                                                                                                                                                 
  - PopularReviewRepository — @Modifying JPQL delete 추가                                                                                                                                                 
                                                                                                                                                                                                            
  인기 리뷰 조회 API                                                                                                                                                                                      
                                                                                                                                                                                                            
  - GET /api/reviews/popular — 커서 페이지네이션 조회                                                                                                                                                       
  - DashboardFacade → PopularReviewReader → PopularReviewReadQueryBuilder
  - PopularReviewViewModel, PopularReviewResponse                                                                                                                                                           
  - DashboardMapper에 리뷰 매핑 추가                                                                                                                                                                        
   
  공통 개선                                                                                                                                                                                                 
                                                                                                                                                                                                          
  - DashboardSearchRequestParam — 도서/리뷰 검색 파라미터 통합(유저도 동일) (기존 PopularBookSearchRequestParam, PopularReviewSearchRequestParam 삭제)                                                                   
  - RankedViewModel 인터페이스 — rank(), createdAt() 공통화, DashboardFacade의 페이징 헬퍼 메서드 중복 제거                                                                                               
  - DashboardService → DashboardFacade                                                                                                                                                             
  - DashboardScheduler, DashboardAdminController에 리뷰 배치 호출 추가                                                                                                                                      
  - DashboardAdminApi 인터페이스 + Swagger 문서화 추가, 응답 204로 변경                                       

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [ ] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 인기 리뷰 조회 API 엔드포인트 추가 (`/api/reviews/popular`)
  * 기간별(일일, 주간, 월간, 전체) 인기 리뷰 필터링 지원
  * 좋아요와 댓글 수의 가중치를 반영한 인기도 점수 계산

* **개선**
  * 대시보드 API 통일: 기존 인기 도서 조회 파라미터 표준화
  * 인기 도서 정렬 알고리즘 개선 (생성 시간 기반 정렬)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->