### PR TITLE
feat: 대시보드 관리 파워 유저 구현

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/book/service/BookService.java
@@ -12,6 +12,7 @@ import com.codeit.team4.deokhugam.naver.NaverBookClient;
 import com.codeit.team4.deokhugam.naver.NaverBookResponse;
 import com.codeit.team4.deokhugam.s3.S3Service;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -71,6 +72,11 @@ public class BookService {
         return bookRepository.findByIdAndDeletedAtIsNull(bookId)
                 .orElseThrow(() -> new BusinessException(
                         ErrorCode.BOOK_NOT_FOUND, "bookId=" + bookId));
+    }
+
+    @Transactional(readOnly = true)
+    public List<Book> findAllByIds(List<UUID> bookIds) {
+        return bookRepository.findAllById(bookIds);
     }
 
     @Transactional

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PowerUserAggregationQueryBuilder.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PowerUserAggregationQueryBuilder.java
@@ -1,0 +1,77 @@
+package com.codeit.team4.deokhugam.dashboard.builder;
+
+import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
+import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
+
+import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
+import com.codeit.team4.deokhugam.dashboard.entity.PopularReview;
+import com.codeit.team4.deokhugam.dashboard.entity.PowerUser;
+import java.math.BigDecimal;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+import org.jooq.Condition;
+import org.jooq.SortField;
+import org.jooq.impl.DSL;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PowerUserAggregationQueryBuilder {
+
+    @Value("${dashboard.batch.zone}")
+    private String zone;
+
+    public Condition buildCondition(PeriodType period, LocalDate snapshotDate) {
+        return DSL.and(
+                REVIEWS.DELETED_AT.isNull(),
+                startDateCondition(period, snapshotDate),
+                endDateCondition(snapshotDate)
+        );
+    }
+
+    public List<SortField<?>> buildOrderBy() {
+        SortField<?> scoreDesc = DSL.sum(
+                REVIEWS.LIKE_COUNT.cast(BigDecimal.class).mul(PopularReview.LIKE_COUNT_WEIGHT)
+                        .add(REVIEWS.COMMENT_COUNT.cast(BigDecimal.class).mul(PopularReview.COMMENT_COUNT_WEIGHT))
+        ).cast(BigDecimal.class).mul(PowerUser.REVIEW_SCORE_SUM_WEIGHT)
+                .add(DSL.sum(REVIEWS.LIKE_COUNT).cast(BigDecimal.class).mul(PowerUser.LIKE_COUNT_WEIGHT))
+                .add(DSL.sum(REVIEWS.COMMENT_COUNT).cast(BigDecimal.class).mul(PowerUser.COMMENT_COUNT_WEIGHT))
+                .desc();
+
+        return List.of(scoreDesc, USERS.CREATED_AT.asc());
+    }
+
+    private Condition startDateCondition(PeriodType period, LocalDate snapshotDate) {
+        OffsetDateTime startDateTime = getStartDateTime(period, snapshotDate);
+        if (startDateTime == null) {
+            return DSL.noCondition();
+        }
+        return REVIEWS.CREATED_AT.greaterOrEqual(startDateTime);
+    }
+
+    private Condition endDateCondition(LocalDate snapshotDate) {
+        OffsetDateTime endDateTime = snapshotDate.plusDays(1)
+                .atStartOfDay(ZoneId.of(zone))
+                .toOffsetDateTime();
+        return REVIEWS.CREATED_AT.lessThan(endDateTime);
+    }
+
+    private OffsetDateTime getStartDateTime(PeriodType period, LocalDate snapshotDate) {
+        LocalDate startDate = switch (period) {
+            case DAILY -> snapshotDate;
+            case WEEKLY -> snapshotDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+            case MONTHLY -> snapshotDate.withDayOfMonth(1);
+            case ALL_TIME -> null;
+        };
+
+        if (startDate == null) {
+            return null;
+        }
+
+        return startDate.atStartOfDay(ZoneId.of(zone)).toOffsetDateTime();
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PowerUserAggregationQueryBuilder.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PowerUserAggregationQueryBuilder.java
@@ -42,7 +42,7 @@ public class PowerUserAggregationQueryBuilder {
                 .add(DSL.sum(REVIEWS.COMMENT_COUNT).cast(BigDecimal.class).mul(PowerUser.COMMENT_COUNT_WEIGHT))
                 .desc();
 
-        return List.of(scoreDesc, USERS.CREATED_AT.asc());
+        return List.of(scoreDesc, USERS.CREATED_AT.asc(), REVIEWS.USER_ID.asc());
     }
 
     private Condition startDateCondition(PeriodType period, LocalDate snapshotDate) {

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PowerUserReadQueryBuilder.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PowerUserReadQueryBuilder.java
@@ -1,0 +1,42 @@
+package com.codeit.team4.deokhugam.dashboard.builder;
+
+import static com.codeit.team4.deokhugam.jooq.tables.PowerUsers.POWER_USERS;
+
+import com.codeit.team4.deokhugam.dashboard.dto.DashboardSearchRequestParam;
+import com.codeit.team4.deokhugam.global.response.SortDirection;
+import java.time.LocalDate;
+import org.jooq.Condition;
+import org.jooq.SortField;
+import org.jooq.impl.DSL;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PowerUserReadQueryBuilder {
+
+    public Condition buildCondition(DashboardSearchRequestParam param, LocalDate latestSnapshotDate) {
+        return DSL.and(
+                POWER_USERS.PERIOD.eq(param.period().name()),
+                POWER_USERS.SNAPSHOT_DATE.eq(latestSnapshotDate),
+                rankCondition(param)
+        );
+    }
+
+    public SortField<?> buildOrderBy(SortDirection direction) {
+        return SortDirection.ASC == direction
+                ? POWER_USERS.RANK.asc()
+                : POWER_USERS.RANK.desc();
+    }
+
+    private Condition rankCondition(DashboardSearchRequestParam param) {
+        Integer cursor = param.cursorAsInteger();
+
+        if (cursor == null) {
+            return DSL.noCondition();
+        }
+
+        return switch (param.direction()) {
+            case ASC -> POWER_USERS.RANK.gt(cursor);
+            case DESC -> POWER_USERS.RANK.lt(cursor);
+        };
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/controller/DashboardAdminController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/controller/DashboardAdminController.java
@@ -28,6 +28,8 @@ public class DashboardAdminController implements DashboardAdminApi {
         LocalDate snapshotDate = LocalDate.now(ZoneId.of(zone));
         log.info("수동 배치 실행 요청: snapshotDate={}", snapshotDate);
         dashboardBatchService.updatePopularBooks(snapshotDate);
+        dashboardBatchService.updatePopularReviews(snapshotDate);
+        dashboardBatchService.updatePowerUsers(snapshotDate);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/controller/DashboardController.java
@@ -4,6 +4,7 @@ import com.codeit.team4.deokhugam.dashboard.controller.api.DashboardApi;
 import com.codeit.team4.deokhugam.dashboard.dto.DashboardSearchRequestParam;
 import com.codeit.team4.deokhugam.dashboard.dto.PopularBookResponse;
 import com.codeit.team4.deokhugam.dashboard.dto.PopularReviewResponse;
+import com.codeit.team4.deokhugam.dashboard.dto.PowerUserResponse;
 import com.codeit.team4.deokhugam.dashboard.service.DashboardFacade;
 import com.codeit.team4.deokhugam.global.response.PageResponse;
 import jakarta.validation.Valid;
@@ -41,5 +42,15 @@ public class DashboardController implements DashboardApi {
                 param.period(), param.direction(), param.limit());
 
         return ResponseEntity.ok(dashboardService.getPopularReviews(param));
+    }
+
+    @GetMapping("/users/power")
+    public ResponseEntity<PageResponse<PowerUserResponse>> getPowerUsers(
+            @Valid @ParameterObject DashboardSearchRequestParam param
+    ) {
+        log.info("파워 유저 목록 조회 요청: period={}, direction={}, limit={}",
+                param.period(), param.direction(), param.limit());
+
+        return ResponseEntity.ok(dashboardService.getPowerUsers(param));
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/controller/api/DashboardApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/controller/api/DashboardApi.java
@@ -3,6 +3,7 @@ package com.codeit.team4.deokhugam.dashboard.controller.api;
 import com.codeit.team4.deokhugam.dashboard.dto.DashboardSearchRequestParam;
 import com.codeit.team4.deokhugam.dashboard.dto.PopularBookResponse;
 import com.codeit.team4.deokhugam.dashboard.dto.PopularReviewResponse;
+import com.codeit.team4.deokhugam.dashboard.dto.PowerUserResponse;
 import com.codeit.team4.deokhugam.global.error.ErrorResponse;
 import com.codeit.team4.deokhugam.global.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,6 +39,18 @@ public interface DashboardApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     ResponseEntity<PageResponse<PopularReviewResponse>> getPopularReviews(
+            @ParameterObject DashboardSearchRequestParam param
+    );
+
+    @Operation(summary = "파워 유저 목록 조회", description = "기간별 파워 유저 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "파워 유저 목록 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (랭킹 기간 오류, 정렬 방향 오류 등)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<PageResponse<PowerUserResponse>> getPowerUsers(
             @ParameterObject DashboardSearchRequestParam param
     );
 }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/dto/PowerUserResponse.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/dto/PowerUserResponse.java
@@ -1,0 +1,43 @@
+package com.codeit.team4.deokhugam.dashboard.dto;
+
+import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Schema(description = "파워 유저 응답")
+public record PowerUserResponse(
+
+        @Schema(description = "파워 유저 ID")
+        UUID id,
+
+        @Schema(description = "사용자 ID")
+        UUID userId,
+
+        @Schema(description = "닉네임")
+        String nickname,
+
+        @Schema(description = "랭킹 기간")
+        PeriodType period,
+
+        @Schema(description = "순위")
+        int rank,
+
+        @Schema(description = "점수")
+        BigDecimal score,
+
+        @Schema(description = "리뷰 점수 합계")
+        BigDecimal reviewScoreSum,
+
+        @Schema(description = "좋아요 수")
+        int likeCount,
+
+        @Schema(description = "댓글 수")
+        int commentCount,
+
+        @Schema(description = "생성 일시")
+        Instant createdAt
+) {
+
+}

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/entity/PopularBook.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/entity/PopularBook.java
@@ -13,6 +13,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.Objects;
 import lombok.AccessLevel;
@@ -92,7 +93,8 @@ public class PopularBook extends BaseEntity {
 
     private BigDecimal calculateScore(int reviewCount, BigDecimal avgRating) {
         return new BigDecimal(reviewCount).multiply(REVIEW_COUNT_WEIGHT)
-                .add(avgRating.multiply(AVG_RATING_WEIGHT));
+                .add(avgRating.multiply(AVG_RATING_WEIGHT))
+                .setScale(4, RoundingMode.HALF_UP);
     }
 
     @Override

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/entity/PopularReview.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/entity/PopularReview.java
@@ -15,6 +15,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.Objects;
 import lombok.AccessLevel;
@@ -116,7 +117,8 @@ public class PopularReview extends BaseEntity {
 
     private BigDecimal calculateScore(int likeCount, int commentCount) {
         return new BigDecimal(likeCount).multiply(LIKE_COUNT_WEIGHT)
-                .add(new BigDecimal(commentCount).multiply(COMMENT_COUNT_WEIGHT));
+                .add(new BigDecimal(commentCount).multiply(COMMENT_COUNT_WEIGHT))
+                .setScale(4, RoundingMode.HALF_UP);
     }
 
     @Override

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/entity/PowerUser.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/entity/PowerUser.java
@@ -32,6 +32,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PowerUser extends BaseEntity {
 
+    public static final BigDecimal REVIEW_SCORE_SUM_WEIGHT = new BigDecimal("0.5");
+    public static final BigDecimal LIKE_COUNT_WEIGHT = new BigDecimal("0.2");
+    public static final BigDecimal COMMENT_COUNT_WEIGHT = new BigDecimal("0.3");
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -66,7 +70,6 @@ public class PowerUser extends BaseEntity {
             String nickname,
             PeriodType period,
             int rank,
-            BigDecimal score,
             BigDecimal reviewScoreSum,
             int likeCount,
             int commentCount,
@@ -76,11 +79,21 @@ public class PowerUser extends BaseEntity {
         this.nickname = nickname;
         this.period = period;
         this.rank = rank;
-        this.score = score;
+        this.score = calculateScore(reviewScoreSum, likeCount, commentCount);
         this.reviewScoreSum = reviewScoreSum;
         this.likeCount = likeCount;
         this.commentCount = commentCount;
         this.snapshotDate = snapshotDate;
+    }
+
+    private BigDecimal calculateScore(
+            BigDecimal reviewScoreSum,
+            int likeCount,
+            int commentCount
+    ) {
+        return reviewScoreSum.multiply(REVIEW_SCORE_SUM_WEIGHT)
+                .add(new BigDecimal(likeCount).multiply(LIKE_COUNT_WEIGHT))
+                .add(new BigDecimal(commentCount).multiply(COMMENT_COUNT_WEIGHT));
     }
 
     @Override

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/entity/PowerUser.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/entity/PowerUser.java
@@ -13,6 +13,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.Objects;
 import lombok.AccessLevel;
@@ -93,7 +94,8 @@ public class PowerUser extends BaseEntity {
     ) {
         return reviewScoreSum.multiply(REVIEW_SCORE_SUM_WEIGHT)
                 .add(new BigDecimal(likeCount).multiply(LIKE_COUNT_WEIGHT))
-                .add(new BigDecimal(commentCount).multiply(COMMENT_COUNT_WEIGHT));
+                .add(new BigDecimal(commentCount).multiply(COMMENT_COUNT_WEIGHT))
+                .setScale(4, RoundingMode.HALF_UP);
     }
 
     @Override

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/mapper/DashboardMapper.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/mapper/DashboardMapper.java
@@ -2,8 +2,10 @@ package com.codeit.team4.deokhugam.dashboard.mapper;
 
 import com.codeit.team4.deokhugam.dashboard.dto.PopularBookResponse;
 import com.codeit.team4.deokhugam.dashboard.dto.PopularReviewResponse;
+import com.codeit.team4.deokhugam.dashboard.dto.PowerUserResponse;
 import com.codeit.team4.deokhugam.dashboard.model.PopularBookViewModel;
 import com.codeit.team4.deokhugam.dashboard.model.PopularReviewViewModel;
+import com.codeit.team4.deokhugam.dashboard.model.PowerUserViewModel;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
@@ -12,4 +14,6 @@ public interface DashboardMapper {
     PopularBookResponse toPopularBookResponse(PopularBookViewModel model);
 
     PopularReviewResponse toPopularReviewResponse(PopularReviewViewModel model);
+
+    PowerUserResponse toPowerUserResponse(PowerUserViewModel model);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/model/PowerUserSearchModel.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/model/PowerUserSearchModel.java
@@ -1,0 +1,60 @@
+package com.codeit.team4.deokhugam.dashboard.model;
+
+import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
+import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
+
+import com.codeit.team4.deokhugam.dashboard.entity.PopularReview;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.impl.DSL;
+
+public record PowerUserSearchModel(
+        UUID userId,
+        String nickname,
+        BigDecimal reviewScoreSum,
+        int likeCount,
+        int commentCount
+) {
+
+    private static final Field<BigDecimal> REVIEW_SCORE_SUM = DSL.sum(
+            REVIEWS.LIKE_COUNT.cast(BigDecimal.class).mul(PopularReview.LIKE_COUNT_WEIGHT)
+                    .add(REVIEWS.COMMENT_COUNT.cast(BigDecimal.class).mul(PopularReview.COMMENT_COUNT_WEIGHT))
+    ).as("review_score_sum");
+
+    private static final Field<BigDecimal> LIKE_COUNT_SUM =
+            DSL.sum(REVIEWS.LIKE_COUNT).as("like_count_sum");
+
+    private static final Field<BigDecimal> COMMENT_COUNT_SUM =
+            DSL.sum(REVIEWS.COMMENT_COUNT).as("comment_count_sum");
+
+    public static List<Field<?>> toSelectedFields() {
+        return List.of(
+                REVIEWS.USER_ID,
+                USERS.NICKNAME,
+                REVIEW_SCORE_SUM,
+                LIKE_COUNT_SUM,
+                COMMENT_COUNT_SUM
+        );
+    }
+
+    public static List<Field<?>> toGroupByFields() {
+        return List.of(
+                REVIEWS.USER_ID,
+                USERS.NICKNAME,
+                USERS.CREATED_AT
+        );
+    }
+
+    public static PowerUserSearchModel fromRecord(Record rec) {
+        return new PowerUserSearchModel(
+                rec.get(REVIEWS.USER_ID),
+                rec.get(USERS.NICKNAME),
+                rec.get(REVIEW_SCORE_SUM),
+                rec.get(LIKE_COUNT_SUM).intValue(),
+                rec.get(COMMENT_COUNT_SUM).intValue()
+        );
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/model/PowerUserViewModel.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/model/PowerUserViewModel.java
@@ -1,0 +1,55 @@
+package com.codeit.team4.deokhugam.dashboard.model;
+
+import static com.codeit.team4.deokhugam.jooq.tables.PowerUsers.POWER_USERS;
+
+import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.jooq.Field;
+import org.jooq.Record;
+
+public record PowerUserViewModel(
+        UUID id,
+        UUID userId,
+        String nickname,
+        PeriodType period,
+        int rank,
+        BigDecimal score,
+        BigDecimal reviewScoreSum,
+        int likeCount,
+        int commentCount,
+        Instant createdAt
+) implements RankedViewModel {
+
+    public static List<Field<?>> toSelectedFields() {
+        return List.of(
+                POWER_USERS.ID,
+                POWER_USERS.USER_ID,
+                POWER_USERS.NICKNAME,
+                POWER_USERS.PERIOD,
+                POWER_USERS.RANK,
+                POWER_USERS.SCORE,
+                POWER_USERS.REVIEW_SCORE_SUM,
+                POWER_USERS.LIKE_COUNT,
+                POWER_USERS.COMMENT_COUNT,
+                POWER_USERS.CREATED_AT
+        );
+    }
+
+    public static PowerUserViewModel fromRecord(Record rec) {
+        return new PowerUserViewModel(
+                rec.get(POWER_USERS.ID),
+                rec.get(POWER_USERS.USER_ID),
+                rec.get(POWER_USERS.NICKNAME),
+                PeriodType.valueOf(rec.get(POWER_USERS.PERIOD)),
+                rec.get(POWER_USERS.RANK),
+                rec.get(POWER_USERS.SCORE),
+                rec.get(POWER_USERS.REVIEW_SCORE_SUM),
+                rec.get(POWER_USERS.LIKE_COUNT),
+                rec.get(POWER_USERS.COMMENT_COUNT),
+                rec.get(POWER_USERS.CREATED_AT).toInstant()
+        );
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/repository/PowerUserRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/repository/PowerUserRepository.java
@@ -1,9 +1,20 @@
 package com.codeit.team4.deokhugam.dashboard.repository;
 
+import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
 import com.codeit.team4.deokhugam.dashboard.entity.PowerUser;
+import java.time.LocalDate;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PowerUserRepository extends JpaRepository<PowerUser, UUID> {
 
+    @Modifying
+    @Query("DELETE FROM PowerUser pu WHERE pu.period = :period AND pu.snapshotDate = :snapshotDate")
+    void deleteByPeriodAndSnapshotDate(
+            @Param("period") PeriodType period,
+            @Param("snapshotDate") LocalDate snapshotDate
+    );
 }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/scheduler/DashboardScheduler.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/scheduler/DashboardScheduler.java
@@ -29,21 +29,18 @@ public class DashboardScheduler {
 
         try {
             dashboardBatchService.updatePopularBooks(snapshotDate);
-            log.info("인기 도서 배치 완료");
         } catch (Exception e) {
             log.error("인기 도서 배치 실패", e);
         }
 
         try {
             dashboardBatchService.updatePopularReviews(snapshotDate);
-            log.info("인기 리뷰 배치 완료");
         } catch (Exception e) {
             log.error("인기 리뷰 배치 실패", e);
         }
 
         try {
             dashboardBatchService.updatePowerUsers(snapshotDate);
-            log.info("파워 유저 배치 완료");
         } catch (Exception e) {
             log.error("파워 유저 배치 실패", e);
         }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/scheduler/DashboardScheduler.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/scheduler/DashboardScheduler.java
@@ -26,19 +26,26 @@ public class DashboardScheduler {
     public void runDashboardBatch() {
         LocalDate snapshotDate = LocalDate.now(ZoneId.of(zone));
         log.info("대시보드 배치 스케줄러 시작: snapshotDate={}", snapshotDate);
+
         try {
             dashboardBatchService.updatePopularBooks(snapshotDate);
-            dashboardBatchService.updatePopularReviews(snapshotDate);
-            dashboardBatchService.updatePowerUsers(snapshotDate);
-            log.info("대시보드 배치 스케줄러 완료");
+            log.info("인기 도서 배치 완료");
         } catch (Exception e) {
             log.error("인기 도서 배치 실패", e);
         }
 
         try {
             dashboardBatchService.updatePopularReviews(snapshotDate);
+            log.info("인기 리뷰 배치 완료");
         } catch (Exception e) {
             log.error("인기 리뷰 배치 실패", e);
+        }
+
+        try {
+            dashboardBatchService.updatePowerUsers(snapshotDate);
+            log.info("파워 유저 배치 완료");
+        } catch (Exception e) {
+            log.error("파워 유저 배치 실패", e);
         }
 
         log.info("대시보드 배치 스케줄러 종료");

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/scheduler/DashboardScheduler.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/scheduler/DashboardScheduler.java
@@ -28,6 +28,9 @@ public class DashboardScheduler {
         log.info("대시보드 배치 스케줄러 시작: snapshotDate={}", snapshotDate);
         try {
             dashboardBatchService.updatePopularBooks(snapshotDate);
+            dashboardBatchService.updatePopularReviews(snapshotDate);
+            dashboardBatchService.updatePowerUsers(snapshotDate);
+            log.info("대시보드 배치 스케줄러 완료");
         } catch (Exception e) {
             log.error("인기 도서 배치 실패", e);
         }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchService.java
@@ -19,6 +19,10 @@ import com.codeit.team4.deokhugam.user.service.UserService;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -32,15 +36,16 @@ public class DashboardBatchService {
 
     private final PopularBookRepository popularBookRepository;
     private final PopularBookAggregator popularBookAggregator;
-    private final BookService bookService;
-
-    private final PopularReviewRepository popularReviewRepository;
-    private final PopularReviewAggregator popularReviewAggregator;
-    private final ReviewService reviewService;
-    private final UserService userService;
 
     private final PowerUserRepository powerUserRepository;
     private final PowerUserAggregator powerUserAggregator;
+
+    private final PopularReviewRepository popularReviewRepository;
+    private final PopularReviewAggregator popularReviewAggregator;
+
+    private final ReviewService reviewService;
+    private final UserService userService;
+    private final BookService bookService;
 
     public void updatePopularBooks(LocalDate snapshotDate) {
         log.info("인기 도서 배치 시작: snapshotDate={}", snapshotDate);
@@ -62,18 +67,31 @@ public class DashboardBatchService {
         log.info("인기 리뷰 배치 완료: snapshotDate={}", snapshotDate);
     }
 
+    public void updatePowerUsers(LocalDate snapshotDate) {
+        log.info("파워 유저 배치 시작: snapshotDate={}", snapshotDate);
+
+        for (PeriodType period : PeriodType.values()) {
+            updatePowerUsersByPeriod(period, snapshotDate);
+        }
+
+        log.info("파워 유저 배치 완료: snapshotDate={}", snapshotDate);
+    }
+
     private void updatePopularBooksByPeriod(PeriodType period, LocalDate snapshotDate) {
         popularBookRepository.deleteByPeriodAndSnapshotDate(period, snapshotDate);
 
         List<PopularBookSearchModel> results = popularBookAggregator.findTopBooks(period, snapshotDate);
 
+        List<UUID> bookIds = results.stream().map(PopularBookSearchModel::bookId).toList();
+        Map<UUID, Book> bookMap = bookService.findAllByIds(bookIds).stream()
+                .collect(Collectors.toMap(Book::getId, Function.identity()));
+
         List<PopularBook> popularBooks = new ArrayList<>();
         for (int i = 0; i < results.size(); i++) {
             PopularBookSearchModel model = results.get(i);
-            Book book = bookService.findById(model.bookId());
 
             popularBooks.add(new PopularBook(
-                    book,
+                    bookMap.get(model.bookId()),
                     model.title(),
                     model.author(),
                     model.thumbnailUrl(),
@@ -94,17 +112,25 @@ public class DashboardBatchService {
 
         List<PopularReviewSearchModel> results = popularReviewAggregator.findTopReviews(period, snapshotDate);
 
+        List<UUID> reviewIds = results.stream().map(PopularReviewSearchModel::reviewId).toList();
+        List<UUID> bookIds = results.stream().map(PopularReviewSearchModel::bookId).toList();
+        List<UUID> userIds = results.stream().map(PopularReviewSearchModel::userId).toList();
+
+        Map<UUID, Review> reviewMap = reviewService.findAllByIds(reviewIds).stream()
+                .collect(Collectors.toMap(Review::getId, Function.identity()));
+        Map<UUID, Book> bookMap = bookService.findAllByIds(bookIds).stream()
+                .collect(Collectors.toMap(Book::getId, Function.identity()));
+        Map<UUID, User> userMap = userService.findAllByIds(userIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
         List<PopularReview> popularReviews = new ArrayList<>();
         for (int i = 0; i < results.size(); i++) {
             PopularReviewSearchModel model = results.get(i);
-            Review review = reviewService.findById(model.reviewId());
-            Book book = bookService.findById(model.bookId());
-            User user = userService.findById(model.userId());
 
             popularReviews.add(new PopularReview(
-                    review,
-                    book,
-                    user,
+                    reviewMap.get(model.reviewId()),
+                    bookMap.get(model.bookId()),
+                    userMap.get(model.userId()),
                     model.bookTitle(),
                     model.bookThumbnailUrl(),
                     model.userNickname(),
@@ -122,28 +148,21 @@ public class DashboardBatchService {
         log.info("인기 리뷰 {} 저장 완료: {}건", period, popularReviews.size());
     }
 
-    public void updatePowerUsers(LocalDate snapshotDate) {
-        log.info("파워 유저 배치 시작: snapshotDate={}", snapshotDate);
-
-        for (PeriodType period : PeriodType.values()) {
-            updatePowerUsersByPeriod(period, snapshotDate);
-        }
-
-        log.info("파워 유저 배치 완료: snapshotDate={}", snapshotDate);
-    }
-
     private void updatePowerUsersByPeriod(PeriodType period, LocalDate snapshotDate) {
         powerUserRepository.deleteByPeriodAndSnapshotDate(period, snapshotDate);
 
         List<PowerUserSearchModel> results = powerUserAggregator.findTopPowerUsers(period, snapshotDate);
 
+        List<UUID> userIds = results.stream().map(PowerUserSearchModel::userId).toList();
+        Map<UUID, User> userMap = userService.findAllByIds(userIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
+
         List<PowerUser> powerUsers = new ArrayList<>();
         for (int i = 0; i < results.size(); i++) {
             PowerUserSearchModel model = results.get(i);
-            User user = userService.findById(model.userId());
 
             powerUsers.add(new PowerUser(
-                    user,
+                    userMap.get(model.userId()),
                     model.nickname(),
                     period,
                     i + 1,

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchService.java
@@ -5,10 +5,13 @@ import com.codeit.team4.deokhugam.book.service.BookService;
 import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
 import com.codeit.team4.deokhugam.dashboard.entity.PopularBook;
 import com.codeit.team4.deokhugam.dashboard.entity.PopularReview;
+import com.codeit.team4.deokhugam.dashboard.entity.PowerUser;
 import com.codeit.team4.deokhugam.dashboard.model.PopularBookSearchModel;
 import com.codeit.team4.deokhugam.dashboard.model.PopularReviewSearchModel;
+import com.codeit.team4.deokhugam.dashboard.model.PowerUserSearchModel;
 import com.codeit.team4.deokhugam.dashboard.repository.PopularBookRepository;
 import com.codeit.team4.deokhugam.dashboard.repository.PopularReviewRepository;
+import com.codeit.team4.deokhugam.dashboard.repository.PowerUserRepository;
 import com.codeit.team4.deokhugam.review.entity.Review;
 import com.codeit.team4.deokhugam.review.service.ReviewService;
 import com.codeit.team4.deokhugam.user.entity.User;
@@ -35,6 +38,9 @@ public class DashboardBatchService {
     private final PopularReviewAggregator popularReviewAggregator;
     private final ReviewService reviewService;
     private final UserService userService;
+
+    private final PowerUserRepository powerUserRepository;
+    private final PowerUserAggregator powerUserAggregator;
 
     public void updatePopularBooks(LocalDate snapshotDate) {
         log.info("인기 도서 배치 시작: snapshotDate={}", snapshotDate);
@@ -114,5 +120,41 @@ public class DashboardBatchService {
 
         popularReviewRepository.saveAll(popularReviews);
         log.info("인기 리뷰 {} 저장 완료: {}건", period, popularReviews.size());
+    }
+
+    public void updatePowerUsers(LocalDate snapshotDate) {
+        log.info("파워 유저 배치 시작: snapshotDate={}", snapshotDate);
+
+        for (PeriodType period : PeriodType.values()) {
+            updatePowerUsersByPeriod(period, snapshotDate);
+        }
+
+        log.info("파워 유저 배치 완료: snapshotDate={}", snapshotDate);
+    }
+
+    private void updatePowerUsersByPeriod(PeriodType period, LocalDate snapshotDate) {
+        powerUserRepository.deleteByPeriodAndSnapshotDate(period, snapshotDate);
+
+        List<PowerUserSearchModel> results = powerUserAggregator.findTopPowerUsers(period, snapshotDate);
+
+        List<PowerUser> powerUsers = new ArrayList<>();
+        for (int i = 0; i < results.size(); i++) {
+            PowerUserSearchModel model = results.get(i);
+            User user = userService.findById(model.userId());
+
+            powerUsers.add(new PowerUser(
+                    user,
+                    model.nickname(),
+                    period,
+                    i + 1,
+                    model.reviewScoreSum(),
+                    model.likeCount(),
+                    model.commentCount(),
+                    snapshotDate
+            ));
+        }
+
+        powerUserRepository.saveAll(powerUsers);
+        log.info("파워 유저 {} 저장 완료: {}건", period, powerUsers.size());
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacade.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacade.java
@@ -3,9 +3,11 @@ package com.codeit.team4.deokhugam.dashboard.service;
 import com.codeit.team4.deokhugam.dashboard.dto.DashboardSearchRequestParam;
 import com.codeit.team4.deokhugam.dashboard.dto.PopularBookResponse;
 import com.codeit.team4.deokhugam.dashboard.dto.PopularReviewResponse;
+import com.codeit.team4.deokhugam.dashboard.dto.PowerUserResponse;
 import com.codeit.team4.deokhugam.dashboard.mapper.DashboardMapper;
 import com.codeit.team4.deokhugam.dashboard.model.PopularBookViewModel;
 import com.codeit.team4.deokhugam.dashboard.model.PopularReviewViewModel;
+import com.codeit.team4.deokhugam.dashboard.model.PowerUserViewModel;
 import com.codeit.team4.deokhugam.dashboard.model.RankedViewModel;
 import com.codeit.team4.deokhugam.global.response.PageResponse;
 import java.time.Instant;
@@ -24,6 +26,7 @@ public class DashboardFacade {
 
     private final PopularBookReader popularBookReader;
     private final PopularReviewReader popularReviewReader;
+    private final PowerUserReader powerUserReader;
     private final DashboardMapper dashboardMapper;
 
     public PageResponse<PopularBookResponse> getPopularBooks(DashboardSearchRequestParam param) {
@@ -64,6 +67,27 @@ public class DashboardFacade {
 
         List<PopularReviewResponse> responses = content.stream()
                 .map(dashboardMapper::toPopularReviewResponse)
+                .toList();
+
+        return new PageResponse<>(
+                responses,
+                extractNextCursor(content, hasNext),
+                extractNextAfter(content, hasNext),
+                param.limit(),
+                null,
+                hasNext
+        );
+    }
+
+    public PageResponse<PowerUserResponse> getPowerUsers(DashboardSearchRequestParam param) {
+        LocalDate latestSnapshotDate = powerUserReader.findLatestSnapshotDate(param.period());
+        List<PowerUserViewModel> results = powerUserReader.findPowerUsers(param, latestSnapshotDate);
+
+        List<PowerUserViewModel> content = trimToLimit(results, param.limit());
+        boolean hasNext = results.size() > param.limit();
+
+        List<PowerUserResponse> responses = content.stream()
+                .map(dashboardMapper::toPowerUserResponse)
                 .toList();
 
         return new PageResponse<>(

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacade.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacade.java
@@ -81,6 +81,9 @@ public class DashboardFacade {
 
     public PageResponse<PowerUserResponse> getPowerUsers(DashboardSearchRequestParam param) {
         LocalDate latestSnapshotDate = powerUserReader.findLatestSnapshotDate(param.period());
+        if (latestSnapshotDate == null) {
+            return new PageResponse<>(List.of(), null, null, param.limit(), null, false);
+        }
         List<PowerUserViewModel> results = powerUserReader.findPowerUsers(param, latestSnapshotDate);
 
         List<PowerUserViewModel> content = trimToLimit(results, param.limit());

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/service/PowerUserAggregator.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/service/PowerUserAggregator.java
@@ -1,0 +1,36 @@
+package com.codeit.team4.deokhugam.dashboard.service;
+
+import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
+import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
+
+import com.codeit.team4.deokhugam.dashboard.builder.PowerUserAggregationQueryBuilder;
+import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
+import com.codeit.team4.deokhugam.dashboard.model.PowerUserSearchModel;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PowerUserAggregator {
+
+    private static final int POWER_USER_LIMIT = 10;
+
+    private final DSLContext dsl;
+    private final PowerUserAggregationQueryBuilder aggregationQueryBuilder;
+
+    public List<PowerUserSearchModel> findTopPowerUsers(PeriodType period, LocalDate snapshotDate) {
+        return dsl.select(PowerUserSearchModel.toSelectedFields())
+                .from(REVIEWS)
+                .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
+                .where(aggregationQueryBuilder.buildCondition(period, snapshotDate))
+                .groupBy(PowerUserSearchModel.toGroupByFields())
+                .orderBy(aggregationQueryBuilder.buildOrderBy())
+                .limit(POWER_USER_LIMIT)
+                .fetch(PowerUserSearchModel::fromRecord);
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/service/PowerUserReader.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/service/PowerUserReader.java
@@ -1,0 +1,43 @@
+package com.codeit.team4.deokhugam.dashboard.service;
+
+import static com.codeit.team4.deokhugam.jooq.tables.PowerUsers.POWER_USERS;
+
+import com.codeit.team4.deokhugam.dashboard.builder.PowerUserReadQueryBuilder;
+import com.codeit.team4.deokhugam.dashboard.dto.DashboardSearchRequestParam;
+import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
+import com.codeit.team4.deokhugam.dashboard.model.PowerUserViewModel;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PowerUserReader {
+
+    private final DSLContext dsl;
+    private final PowerUserReadQueryBuilder readQueryBuilder;
+
+    public LocalDate findLatestSnapshotDate(PeriodType period) {
+        return dsl.select(DSL.max(POWER_USERS.SNAPSHOT_DATE))
+                .from(POWER_USERS)
+                .where(POWER_USERS.PERIOD.eq(period.name()))
+                .fetchOneInto(LocalDate.class);
+    }
+
+    public List<PowerUserViewModel> findPowerUsers(
+            DashboardSearchRequestParam param,
+            LocalDate snapshotDate
+    ) {
+        return dsl.select(PowerUserViewModel.toSelectedFields())
+                .from(POWER_USERS)
+                .where(readQueryBuilder.buildCondition(param, snapshotDate))
+                .orderBy(readQueryBuilder.buildOrderBy(param.direction()))
+                .limit(param.limit() + 1) // +1로 다음 페이지 존재 여부(hasNext) 판단
+                .fetch(PowerUserViewModel::fromRecord);
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
@@ -16,6 +16,7 @@ import com.codeit.team4.deokhugam.review.repository.ReviewLikeRepository;
 import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
 import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.service.UserService;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -66,6 +67,10 @@ public class ReviewService {
         return reviewRepository.findByIdAndDeletedAtIsNull(reviewId)
                 .orElseThrow(() -> new BusinessException(
                         ErrorCode.REVIEW_NOT_FOUND, "reviewId=" + reviewId));
+    }
+
+    public List<Review> findAllByIds(List<UUID> reviewIds) {
+        return reviewRepository.findAllById(reviewIds);
     }
 
     public Review findWithDeletedById(UUID reviewId) {

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
@@ -12,6 +12,7 @@ import com.codeit.team4.deokhugam.user.repository.UserJooqRepository;
 import com.codeit.team4.deokhugam.user.repository.UserRepository;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -70,6 +71,10 @@ public class UserService {
         return userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new BusinessException(
                         ErrorCode.USER_NOT_FOUND, "userId=" + userId));
+    }
+
+    public List<User> findAllByIds(List<UUID> userIds) {
+        return userRepository.findAllById(userIds);
     }
 
     @Transactional

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/builder/PowerUserAggregationQueryBuilderTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/builder/PowerUserAggregationQueryBuilderTest.java
@@ -1,6 +1,5 @@
 package com.codeit.team4.deokhugam.dashboard.builder;
 
-import static com.codeit.team4.deokhugam.jooq.tables.Books.BOOKS;
 import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
 import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,11 +8,11 @@ import com.codeit.team4.deokhugam.book.entity.Book;
 import com.codeit.team4.deokhugam.book.repository.BookRepository;
 import com.codeit.team4.deokhugam.config.TestContainerConfig;
 import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
+import com.codeit.team4.deokhugam.dashboard.model.PowerUserSearchModel;
 import com.codeit.team4.deokhugam.review.entity.Review;
 import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
 import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.repository.UserRepository;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
@@ -35,10 +34,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Import(TestContainerConfig.class)
 @ActiveProfiles("test")
 @Transactional
-class PopularReviewAggregationQueryBuilderTest {
+class PowerUserAggregationQueryBuilderTest {
 
     @Autowired
-    private PopularReviewAggregationQueryBuilder queryBuilder;
+    private PowerUserAggregationQueryBuilder queryBuilder;
 
     @Autowired
     private DSLContext dsl;
@@ -67,7 +66,6 @@ class PopularReviewAggregationQueryBuilderTest {
     private int countWithCondition(Condition condition) {
         return dsl.selectCount()
                 .from(REVIEWS)
-                .join(BOOKS).on(REVIEWS.BOOK_ID.eq(BOOKS.ID))
                 .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
                 .where(condition)
                 .fetchOne(0, int.class);
@@ -147,19 +145,6 @@ class PopularReviewAggregationQueryBuilderTest {
 
             assertThat(countWithCondition(condition)).isZero();
         }
-
-        @Test
-        @DisplayName("소프트 삭제된 도서 제외 성공")
-        void buildCondition_excludesSoftDeletedBook_success() {
-            reviewRepository.saveAndFlush(new Review(book, user, "좋은 책입니다", 5));
-            book.softDelete(Instant.now());
-            bookRepository.saveAndFlush(book);
-
-            LocalDate today = LocalDate.now(ZoneId.of(zone));
-            Condition condition = queryBuilder.buildCondition(PeriodType.ALL_TIME, today);
-
-            assertThat(countWithCondition(condition)).isZero();
-        }
     }
 
     @Nested
@@ -167,68 +152,35 @@ class PopularReviewAggregationQueryBuilderTest {
     class OrderByCondition {
 
         @Test
-        @DisplayName("정렬 조건 3개 생성 성공")
-        void buildOrderBy_hasThreeFields_success() {
-            assertThat(queryBuilder.buildOrderBy()).hasSize(3);
+        @DisplayName("정렬 조건 2개 생성 성공")
+        void buildOrderBy_hasTwoFields_success() {
+            assertThat(queryBuilder.buildOrderBy()).hasSize(2);
         }
 
         @Test
-        @DisplayName("동점 리뷰 정렬 순서 일관성 성공")
-        void buildOrderBy_tieBreaker_success() {
+        @DisplayName("동점 시 먼저 가입한 유저가 우선 성공")
+        void buildOrderBy_tieBreaker_earlierUserFirst_success() {
+            User laterUser = userRepository.saveAndFlush(new User("later@test.com", "나중이", "password123"));
             Book otherBook = bookRepository.saveAndFlush(
                     new Book("다른 책", "다른 저자", "설명", "출판사", LocalDate.of(2024, 2, 1), "1234567891")
             );
             reviewRepository.saveAndFlush(new Review(book, user, "좋은 책입니다", 5));
-            reviewRepository.saveAndFlush(new Review(otherBook, user, "좋은 책입니다", 5));
+            reviewRepository.saveAndFlush(new Review(otherBook, laterUser, "좋은 책입니다", 5));
 
             LocalDate today = LocalDate.now(ZoneId.of(zone));
             Condition condition = queryBuilder.buildCondition(PeriodType.ALL_TIME, today);
 
-            List<UUID> firstResult = dsl.select(REVIEWS.ID)
+            List<UUID> result = dsl.select(REVIEWS.USER_ID)
                     .from(REVIEWS)
-                    .join(BOOKS).on(REVIEWS.BOOK_ID.eq(BOOKS.ID))
                     .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
                     .where(condition)
+                    .groupBy(PowerUserSearchModel.toGroupByFields())
                     .orderBy(queryBuilder.buildOrderBy())
-                    .fetch(REVIEWS.ID);
-
-            List<UUID> secondResult = dsl.select(REVIEWS.ID)
-                    .from(REVIEWS)
-                    .join(BOOKS).on(REVIEWS.BOOK_ID.eq(BOOKS.ID))
-                    .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
-                    .where(condition)
-                    .orderBy(queryBuilder.buildOrderBy())
-                    .fetch(REVIEWS.ID);
-
-            assertThat(firstResult).hasSize(2);
-            assertThat(firstResult).isEqualTo(secondResult);
-        }
-
-        @Test
-        @DisplayName("동점 시 먼저 작성한 리뷰가 우선 성공")
-        void buildOrderBy_tieBreaker_earlierReviewFirst_success() {
-            Review earlierReview = reviewRepository.saveAndFlush(new Review(book, user, "먼저 쓴 리뷰", 5));
-
-            Book otherBook = bookRepository.saveAndFlush(
-                    new Book("다른 책", "다른 저자", "설명", "출판사", LocalDate.of(2024, 2, 1), "1234567891")
-            );
-            User otherUser = userRepository.saveAndFlush(new User("other@test.com", "다른사람", "password123"));
-            Review laterReview = reviewRepository.saveAndFlush(new Review(otherBook, otherUser, "나중에 쓴 리뷰", 5));
-
-            LocalDate today = LocalDate.now(ZoneId.of(zone));
-            Condition condition = queryBuilder.buildCondition(PeriodType.ALL_TIME, today);
-
-            List<UUID> result = dsl.select(REVIEWS.ID)
-                    .from(REVIEWS)
-                    .join(BOOKS).on(REVIEWS.BOOK_ID.eq(BOOKS.ID))
-                    .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
-                    .where(condition)
-                    .orderBy(queryBuilder.buildOrderBy())
-                    .fetch(REVIEWS.ID);
+                    .fetch(REVIEWS.USER_ID);
 
             assertThat(result).hasSize(2);
-            assertThat(result.get(0)).isEqualTo(earlierReview.getId());
-            assertThat(result.get(1)).isEqualTo(laterReview.getId());
+            assertThat(result.get(0)).isEqualTo(user.getId());
+            assertThat(result.get(1)).isEqualTo(laterUser.getId());
         }
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/builder/PowerUserAggregationQueryBuilderTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/builder/PowerUserAggregationQueryBuilderTest.java
@@ -152,9 +152,9 @@ class PowerUserAggregationQueryBuilderTest {
     class OrderByCondition {
 
         @Test
-        @DisplayName("정렬 조건 2개 생성 성공")
-        void buildOrderBy_hasTwoFields_success() {
-            assertThat(queryBuilder.buildOrderBy()).hasSize(2);
+        @DisplayName("정렬 조건 3개 생성 성공")
+        void buildOrderBy_hasThreeFields_success() {
+            assertThat(queryBuilder.buildOrderBy()).hasSize(3);
         }
 
         @Test

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/entity/PowerUserTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/entity/PowerUserTest.java
@@ -1,0 +1,40 @@
+package com.codeit.team4.deokhugam.dashboard.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PowerUserTest {
+
+    @Test
+    @DisplayName("score 계산 성공")
+    void calculateScore_success() {
+        PowerUser powerUser = new PowerUser(
+                null, "테스터",
+                PeriodType.DAILY, 1,
+                new BigDecimal("6.5"),
+                10, 5,
+                LocalDate.of(2026, 4, 23)
+        );
+
+        // score = 6.5 * 0.5 + 10 * 0.2 + 5 * 0.3 = 3.25 + 2.0 + 1.5 = 6.75
+        assertThat(powerUser.getScore()).isEqualByComparingTo(new BigDecimal("6.75"));
+    }
+
+    @Test
+    @DisplayName("활동 없을 때 score 계산 성공")
+    void calculateScore_zero_success() {
+        PowerUser powerUser = new PowerUser(
+                null, "테스터",
+                PeriodType.WEEKLY, 1,
+                BigDecimal.ZERO,
+                0, 0,
+                LocalDate.of(2026, 4, 23)
+        );
+
+        assertThat(powerUser.getScore()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+}

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchServiceTest.java
@@ -292,7 +292,7 @@ class DashboardBatchServiceTest {
                 List<PowerUser> byPeriod = powerUserRepository.findAll().stream()
                         .filter(pu -> pu.getPeriod() == period && pu.getSnapshotDate().equals(today))
                         .toList();
-                assertThat(byPeriod).hasSizeLessThanOrEqualTo(10);
+                assertThat(byPeriod).hasSize(10);
             }
         }
 

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchServiceTest.java
@@ -297,17 +297,24 @@ class DashboardBatchServiceTest {
         }
 
         @Test
-        @DisplayName("ranking 순서 부여 성공")
+        @DisplayName("score 기반 ranking 순서 부여 성공")
         void updatePowerUsers_ranking_success() {
             User otherUser = userRepository.saveAndFlush(new User("other@test.com", "다른사람", "password123"));
             Book book1 = createBook("책1", "1111111111");
             Book book2 = createBook("책2", "2222222222");
             Book book3 = createBook("책3", "3333333333");
-            // user가 리뷰 2개 → 점수 높음
-            reviewRepository.saveAndFlush(new Review(book1, user, "좋아요", 5));
-            reviewRepository.saveAndFlush(new Review(book2, user, "또 좋아요", 5));
-            // otherUser가 리뷰 1개 → 점수 낮음
-            reviewRepository.saveAndFlush(new Review(book3, otherUser, "괜찮아요", 3));
+            Review review1 = reviewRepository.saveAndFlush(new Review(book1, user, "좋아요", 5));
+            Review review2 = reviewRepository.saveAndFlush(new Review(book2, user, "또 좋아요", 5));
+            Review review3 = reviewRepository.saveAndFlush(new Review(book3, otherUser, "괜찮아요", 3));
+
+            // user 리뷰: like=10, comment=5 각각 → 활동 점수 높음
+            dsl.update(REVIEWS).set(REVIEWS.LIKE_COUNT, 10).set(REVIEWS.COMMENT_COUNT, 5)
+                    .where(REVIEWS.ID.eq(review1.getId())).execute();
+            dsl.update(REVIEWS).set(REVIEWS.LIKE_COUNT, 8).set(REVIEWS.COMMENT_COUNT, 4)
+                    .where(REVIEWS.ID.eq(review2.getId())).execute();
+            // otherUser 리뷰: like=1, comment=0 → 활동 점수 낮음
+            dsl.update(REVIEWS).set(REVIEWS.LIKE_COUNT, 1).set(REVIEWS.COMMENT_COUNT, 0)
+                    .where(REVIEWS.ID.eq(review3.getId())).execute();
 
             LocalDate today = LocalDate.now(ZoneId.of(zone));
             dashboardBatchService.updatePowerUsers(today);
@@ -320,7 +327,7 @@ class DashboardBatchServiceTest {
             assertThat(dailyUsers).hasSize(2);
             assertThat(dailyUsers.get(0).getRank()).isEqualTo(1);
             assertThat(dailyUsers.get(1).getRank()).isEqualTo(2);
-            assertThat(dailyUsers.get(0).getScore()).isGreaterThanOrEqualTo(dailyUsers.get(1).getScore());
+            assertThat(dailyUsers.get(0).getScore()).isGreaterThan(dailyUsers.get(1).getScore());
         }
 
         @Test

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchServiceTest.java
@@ -8,8 +8,10 @@ import com.codeit.team4.deokhugam.config.TestContainerConfig;
 import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
 import com.codeit.team4.deokhugam.dashboard.entity.PopularBook;
 import com.codeit.team4.deokhugam.dashboard.entity.PopularReview;
+import com.codeit.team4.deokhugam.dashboard.entity.PowerUser;
 import com.codeit.team4.deokhugam.dashboard.repository.PopularBookRepository;
 import com.codeit.team4.deokhugam.dashboard.repository.PopularReviewRepository;
+import com.codeit.team4.deokhugam.dashboard.repository.PowerUserRepository;
 import com.codeit.team4.deokhugam.review.entity.Review;
 import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
 import com.codeit.team4.deokhugam.user.entity.User;
@@ -44,6 +46,9 @@ class DashboardBatchServiceTest {
 
     @Autowired
     private PopularReviewRepository popularReviewRepository;
+
+    @Autowired
+    private PowerUserRepository powerUserRepository;
 
     @Autowired
     private ReviewRepository reviewRepository;
@@ -248,6 +253,97 @@ class DashboardBatchServiceTest {
             for (PeriodType period : PeriodType.values()) {
                 List<PopularReview> byPeriod = popularReviewRepository.findAll().stream()
                         .filter(pr -> pr.getPeriod() == period && pr.getSnapshotDate().equals(today))
+                        .toList();
+                assertThat(byPeriod).isNotEmpty();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("파워 유저 배치")
+    class UpdatePowerUsers {
+
+        @Test
+        @DisplayName("파워 유저 배치 실행 성공")
+        void updatePowerUsers_success() {
+            Book book1 = createBook("책1", "1111111111");
+            reviewRepository.saveAndFlush(new Review(book1, user, "좋아요", 5));
+
+            LocalDate today = LocalDate.now(ZoneId.of(zone));
+            dashboardBatchService.updatePowerUsers(today);
+
+            List<PowerUser> results = powerUserRepository.findAll();
+            assertThat(results).isNotEmpty();
+        }
+
+        @Test
+        @DisplayName("LIMIT 10 적용 성공")
+        void updatePowerUsers_limit_success() {
+            for (int i = 0; i < 15; i++) {
+                User u = userRepository.saveAndFlush(new User("user" + i + "@test.com", "유저" + i, "password123"));
+                Book b = createBook("책" + i, "100000000" + String.format("%02d", i));
+                reviewRepository.saveAndFlush(new Review(b, u, "리뷰" + i, (i % 5) + 1));
+            }
+
+            LocalDate today = LocalDate.now(ZoneId.of(zone));
+            dashboardBatchService.updatePowerUsers(today);
+
+            for (PeriodType period : PeriodType.values()) {
+                List<PowerUser> byPeriod = powerUserRepository.findAll().stream()
+                        .filter(pu -> pu.getPeriod() == period && pu.getSnapshotDate().equals(today))
+                        .toList();
+                assertThat(byPeriod).hasSizeLessThanOrEqualTo(10);
+            }
+        }
+
+        @Test
+        @DisplayName("ranking 순서 부여 성공")
+        void updatePowerUsers_ranking_success() {
+            User otherUser = userRepository.saveAndFlush(new User("other@test.com", "다른사람", "password123"));
+            Book book1 = createBook("책1", "1111111111");
+            Book book2 = createBook("책2", "2222222222");
+            Book book3 = createBook("책3", "3333333333");
+            // user가 리뷰 2개 → 점수 높음
+            reviewRepository.saveAndFlush(new Review(book1, user, "좋아요", 5));
+            reviewRepository.saveAndFlush(new Review(book2, user, "또 좋아요", 5));
+            // otherUser가 리뷰 1개 → 점수 낮음
+            reviewRepository.saveAndFlush(new Review(book3, otherUser, "괜찮아요", 3));
+
+            LocalDate today = LocalDate.now(ZoneId.of(zone));
+            dashboardBatchService.updatePowerUsers(today);
+
+            List<PowerUser> dailyUsers = powerUserRepository.findAll().stream()
+                    .filter(pu -> pu.getPeriod() == PeriodType.DAILY && pu.getSnapshotDate().equals(today))
+                    .sorted((a, b) -> Integer.compare(a.getRank(), b.getRank()))
+                    .toList();
+
+            assertThat(dailyUsers).hasSize(2);
+            assertThat(dailyUsers.get(0).getRank()).isEqualTo(1);
+            assertThat(dailyUsers.get(1).getRank()).isEqualTo(2);
+            assertThat(dailyUsers.get(0).getScore()).isGreaterThanOrEqualTo(dailyUsers.get(1).getScore());
+        }
+
+        @Test
+        @DisplayName("리뷰 없을 때 빈 결과 반환 성공")
+        void updatePowerUsers_noReviews_success() {
+            LocalDate today = LocalDate.now(ZoneId.of(zone));
+            dashboardBatchService.updatePowerUsers(today);
+
+            assertThat(powerUserRepository.findAll()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("모든 PeriodType에 대해 배치 실행 성공")
+        void updatePowerUsers_allPeriods_success() {
+            Book book1 = createBook("책1", "1111111111");
+            reviewRepository.saveAndFlush(new Review(book1, user, "좋아요", 5));
+
+            LocalDate today = LocalDate.now(ZoneId.of(zone));
+            dashboardBatchService.updatePowerUsers(today);
+
+            for (PeriodType period : PeriodType.values()) {
+                List<PowerUser> byPeriod = powerUserRepository.findAll().stream()
+                        .filter(pu -> pu.getPeriod() == period && pu.getSnapshotDate().equals(today))
                         .toList();
                 assertThat(byPeriod).isNotEmpty();
             }

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacadeTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacadeTest.java
@@ -334,6 +334,58 @@ class DashboardFacadeTest {
         }
 
         @Test
+        @DisplayName("DESC 정렬 조회 성공")
+        void getPowerUsers_desc_success() {
+            LocalDate snapshotDate = LocalDate.now(ZoneId.of(zone));
+            User otherUser = userRepository.saveAndFlush(new User("other@test.com", "다른사람", "password123"));
+            Book book1 = createBook("책1", "1111111111");
+            Book book2 = createBook("책2", "2222222222");
+            reviewRepository.saveAndFlush(new Review(book1, user, "좋아요", 5));
+            reviewRepository.saveAndFlush(new Review(book2, otherUser, "괜찮아요", 3));
+            runBatch(snapshotDate);
+
+            DashboardSearchRequestParam param = new DashboardSearchRequestParam(
+                    PeriodType.DAILY, SortDirection.DESC, null, null, 50
+            );
+
+            PageResponse<PowerUserResponse> result = dashboardService.getPowerUsers(param);
+
+            assertThat(result.content()).hasSize(2);
+            assertThat(result.content().get(0).rank()).isEqualTo(2);
+            assertThat(result.content().get(1).rank()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("커서 페이지네이션 성공")
+        void getPowerUsers_cursor_success() {
+            LocalDate snapshotDate = LocalDate.now(ZoneId.of(zone));
+            for (int i = 0; i < 3; i++) {
+                User u = userRepository.saveAndFlush(new User("user" + i + "@test.com", "유저" + i, "password123"));
+                Book b = createBook("책" + i, "100000000" + i);
+                reviewRepository.saveAndFlush(new Review(b, u, "리뷰" + i, 5 - i));
+            }
+            runBatch(snapshotDate);
+
+            DashboardSearchRequestParam firstPage = new DashboardSearchRequestParam(
+                    PeriodType.DAILY, SortDirection.ASC, null, null, 2
+            );
+            PageResponse<PowerUserResponse> firstResult = dashboardService.getPowerUsers(firstPage);
+
+            assertThat(firstResult.content()).hasSize(2);
+            assertThat(firstResult.hasNext()).isTrue();
+            assertThat(firstResult.nextCursor()).isNotNull();
+
+            DashboardSearchRequestParam secondPage = new DashboardSearchRequestParam(
+                    PeriodType.DAILY, SortDirection.ASC,
+                    firstResult.nextCursor(), firstResult.nextAfter(), 2
+            );
+            PageResponse<PowerUserResponse> secondResult = dashboardService.getPowerUsers(secondPage);
+
+            assertThat(secondResult.content()).hasSize(1);
+            assertThat(secondResult.hasNext()).isFalse();
+        }
+
+        @Test
         @DisplayName("잘못된 cursor로 조회 실패")
         void getPowerUsers_invalidCursor_fail() {
             LocalDate snapshotDate = LocalDate.now(ZoneId.of(zone));

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacadeTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardFacadeTest.java
@@ -8,6 +8,7 @@ import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.book.repository.BookRepository;
 import com.codeit.team4.deokhugam.config.TestContainerConfig;
 import com.codeit.team4.deokhugam.dashboard.dto.PopularBookResponse;
+import com.codeit.team4.deokhugam.dashboard.dto.PowerUserResponse;
 import com.codeit.team4.deokhugam.dashboard.dto.PopularReviewResponse;
 import com.codeit.team4.deokhugam.dashboard.dto.DashboardSearchRequestParam;
 import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
@@ -70,6 +71,7 @@ class DashboardFacadeTest {
     private void runBatch(LocalDate snapshotDate) {
         dashboardBatchService.updatePopularBooks(snapshotDate);
         dashboardBatchService.updatePopularReviews(snapshotDate);
+        dashboardBatchService.updatePowerUsers(snapshotDate);
     }
 
     @Nested
@@ -288,6 +290,62 @@ class DashboardFacadeTest {
             );
 
             assertThatThrownBy(() -> dashboardService.getPopularReviews(param))
+                    .isInstanceOf(BusinessException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("파워 유저 조회")
+    class GetPowerUsers {
+
+        @Test
+        @DisplayName("파워 유저 조회 성공")
+        void getPowerUsers_success() {
+            LocalDate snapshotDate = LocalDate.now(ZoneId.of(zone));
+            Book book1 = createBook("책1", "1111111111");
+            reviewRepository.saveAndFlush(new Review(book1, user, "좋아요", 5));
+            runBatch(snapshotDate);
+
+            DashboardSearchRequestParam param = new DashboardSearchRequestParam(
+                    PeriodType.DAILY, SortDirection.ASC, null, null, 50
+            );
+
+            PageResponse<PowerUserResponse> result = dashboardService.getPowerUsers(param);
+
+            assertThat(result.content()).hasSize(1);
+            assertThat(result.content().get(0).rank()).isEqualTo(1);
+            assertThat(result.hasNext()).isFalse();
+            assertThat(result.totalElements()).isNull();
+        }
+
+        @Test
+        @DisplayName("데이터 없을 때 빈 결과 반환 성공")
+        void getPowerUsers_empty_success() {
+            runBatch(LocalDate.now(ZoneId.of(zone)));
+
+            DashboardSearchRequestParam param = new DashboardSearchRequestParam(
+                    PeriodType.DAILY, SortDirection.ASC, null, null, 50
+            );
+
+            PageResponse<PowerUserResponse> result = dashboardService.getPowerUsers(param);
+
+            assertThat(result.content()).isEmpty();
+            assertThat(result.hasNext()).isFalse();
+        }
+
+        @Test
+        @DisplayName("잘못된 cursor로 조회 실패")
+        void getPowerUsers_invalidCursor_fail() {
+            LocalDate snapshotDate = LocalDate.now(ZoneId.of(zone));
+            Book book = createBook("책1", "1111111111");
+            reviewRepository.saveAndFlush(new Review(book, user, "좋아요", 5));
+            runBatch(snapshotDate);
+
+            DashboardSearchRequestParam param = new DashboardSearchRequestParam(
+                    PeriodType.DAILY, SortDirection.ASC, "invalid", null, 50
+            );
+
+            assertThatThrownBy(() -> dashboardService.getPowerUsers(param))
                     .isInstanceOf(BusinessException.class);
         }
     }


### PR DESCRIPTION
## 관련 이슈
- closes #42

## 작업 내용
- 대시보드 관리 파워 유저 구현

## 변경 사항
  파워 유저                                                                                                                                                                                                                                                                                                                                                                                                                                                          
  - 배치: PowerUserAggregator, PowerUserAggregationQueryBuilder (score = reviewScoreSum * 0.5 + likeCount * 0.2 + commentCount * 0.3, LIMIT 10)                                                                                                  
  - 조회: PowerUserReader, PowerUserReadQueryBuilder, GET /api/users/power
  - PowerUser 엔티티 score 자체 계산, PowerUserRepository @Modifying delete 추가                                                                                                                                                                 
                                                                                  

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [ ] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 파워 유저 대시보드 추가로 상위 사용자 순위 조회 가능
  * 기간별 필터링 지원 (일일, 주간, 월간, 전체)
  * 커서 기반 페이지네이션으로 대량 데이터 조회 최적화

* **개선 사항**
  * 배치 처리 성능 개선으로 더 빠른 데이터 업데이트
  * 점수 계산 정확도 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->