### PR TITLE
feat: 레디스 분산락 컴포넌트 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jooq'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.40.2'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jooq'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation 'org.redisson:redisson-spring-boot-starter:3.40.2'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.50.0'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'

--- a/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/error/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // Common
+    LOCK_ACQUISITION_FAILED(HttpStatus.CONFLICT, "현재 다른 요청이 처리 중입니다. 잠시 후 다시 시도해주세요"),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다"),
     MISSING_HEADER(HttpStatus.BAD_REQUEST, "필수 헤더가 누락되었습니다"),
     NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다"),

--- a/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLock.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLock.java
@@ -17,7 +17,12 @@ import java.util.concurrent.TimeUnit;
  * @DistributedLock(key = "deokhugam:book", lockParam = "bookId")
  * public void updateBook(Long bookId, ...) { ... }
  *
- * // 2. 전역 락 (스케줄러 중복 실행 방지)
+ * // 2. 복합 키 락 (request 객체의 필드 조합)
+ * //    락 키: "deokhugam:review:userId값:bookId값"
+ * @DistributedLock(key = "deokhugam:review", lockParam = {"request.userId", "request.bookId"})
+ * public ReviewResponse createReview(ReviewCreateRequest request) { ... }
+ *
+ * // 3. 전역 락 (스케줄러 중복 실행 방지)
  * //    락 키: "dashboard-batch"
  * @DistributedLock(key = "dashboard-batch", waitTime = 0, leaseTime = 30)
  * public void runDashboardBatch() { ... }
@@ -26,7 +31,8 @@ import java.util.concurrent.TimeUnit;
  * <h3>파라미터</h3>
  * <ul>
  *   <li>{@code key} - 락 키 prefix (필수)</li>
- *   <li>{@code lockParam} - 메서드 파라미터 이름. 지정하면 {@code key + ":" + 파라미터값}으로 키 생성</li>
+ *   <li>{@code lockParam} - 메서드 파라미터 이름 배열. 지정하면 {@code key + ":" + 값1 + ":" + 값2}로 키 생성.
+ *       중첩 접근도 가능 (예: {@code "request.userId"})</li>
  *   <li>{@code waitTime} - 락 대기 시간 (기본 5초). 0이면 즉시 실패</li>
  *   <li>{@code leaseTime} - 락 자동 해제 시간 (기본 10초). 메서드 최대 실행 시간보다 길게 설정 필요</li>
  *   <li>{@code timeUnit} - waitTime, leaseTime의 시간 단위 (기본 SECONDS)</li>
@@ -40,7 +46,7 @@ public @interface DistributedLock {
 
     String key();
 
-    String lockParam() default "";
+    String[] lockParam() default {};
 
     long waitTime() default 5;
 

--- a/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLock.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLock.java
@@ -39,6 +39,16 @@ import java.util.concurrent.TimeUnit;
  * </ul>
  *
  * <p>락 획득 실패 시 {@code BusinessException(ErrorCode.LOCK_ACQUISITION_FAILED)}가 발생합니다.</p>
+ *
+ * <h3>주의 사항</h3>
+ * <ul>
+ *   <li><b>Self-invocation 불가</b> - Spring AOP 프록시 기반이므로, 같은 빈 내부에서
+ *       {@code @DistributedLock} 메서드를 직접 호출하면 락이 적용되지 않습니다.
+ *       반드시 다른 빈을 통해 호출해야 합니다.</li>
+ *   <li><b>중첩 접근은 record 전용</b> - {@code "request.userId"} 같은 중첩 접근은
+ *       record의 accessor 메서드({@code userId()})를 호출합니다.
+ *       JavaBeans 스타일 getter({@code getUserId()})는 지원하지 않습니다.</li>
+ * </ul>
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLock.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLock.java
@@ -1,0 +1,50 @@
+package com.codeit.team4.deokhugam.global.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Redis 기반 분산 락을 적용하는 어노테이션.
+ * 메서드에 붙이면 AOP가 실행 전 락을 획득하고, 실행 후 자동으로 해제합니다.
+ *
+ * <h3>사용 예시</h3>
+ * <pre>{@code
+ * // 1. 리소스별 락 (bookId마다 독립된 락)
+ * //    락 키: "deokhugam:book:123"
+ * @DistributedLock(key = "deokhugam:book", lockParam = "bookId")
+ * public void updateBook(Long bookId, ...) { ... }
+ *
+ * // 2. 전역 락 (스케줄러 중복 실행 방지)
+ * //    락 키: "dashboard-batch"
+ * @DistributedLock(key = "dashboard-batch", waitTime = 0, leaseTime = 30)
+ * public void runDashboardBatch() { ... }
+ * }</pre>
+ *
+ * <h3>파라미터</h3>
+ * <ul>
+ *   <li>{@code key} - 락 키 prefix (필수)</li>
+ *   <li>{@code lockParam} - 메서드 파라미터 이름. 지정하면 {@code key + ":" + 파라미터값}으로 키 생성</li>
+ *   <li>{@code waitTime} - 락 대기 시간 (기본 5초). 0이면 즉시 실패</li>
+ *   <li>{@code leaseTime} - 락 자동 해제 시간 (기본 10초). 메서드 최대 실행 시간보다 길게 설정 필요</li>
+ *   <li>{@code timeUnit} - waitTime, leaseTime의 시간 단위 (기본 SECONDS)</li>
+ * </ul>
+ *
+ * <p>락 획득 실패 시 {@code BusinessException(ErrorCode.LOCK_ACQUISITION_FAILED)}가 발생합니다.</p>
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    String key();
+
+    String lockParam() default "";
+
+    long waitTime() default 5;
+
+    long leaseTime() default 10;
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+}

--- a/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspect.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspect.java
@@ -1,0 +1,78 @@
+package com.codeit.team4.deokhugam.global.lock;
+
+import com.codeit.team4.deokhugam.global.error.BusinessException;
+import com.codeit.team4.deokhugam.global.error.ErrorCode;
+import java.lang.reflect.Parameter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class DistributedLockAspect {
+
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(distributedLock)")
+    public Object around(
+            ProceedingJoinPoint joinPoint,
+            DistributedLock distributedLock
+    ) throws Throwable {
+        String lockKey = buildLockKey(distributedLock, joinPoint);
+        RLock lock = redissonClient.getLock(lockKey);
+
+        log.debug("락 획득 시도: {}", lockKey);
+
+        boolean acquired = lock.tryLock(
+                distributedLock.waitTime(),
+                distributedLock.leaseTime(),
+                distributedLock.timeUnit()
+        );
+
+        if (!acquired) {
+            log.debug("락 획득 실패: {}", lockKey);
+            throw new BusinessException(ErrorCode.LOCK_ACQUISITION_FAILED, "락 획득 실패: " + lockKey);
+        }
+
+        log.debug("락 획득 성공: {}", lockKey);
+
+        try {
+            return joinPoint.proceed();
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                log.debug("락 해제: {}", lockKey);
+            }
+        }
+    }
+
+    private String buildLockKey(DistributedLock distributedLock, ProceedingJoinPoint joinPoint) {
+        String key = distributedLock.key();
+        String lockParam = distributedLock.lockParam();
+
+        if (lockParam.isEmpty()) {
+            return key;
+        }
+
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Parameter[] parameters = signature.getMethod().getParameters();
+        Object[] args = joinPoint.getArgs();
+
+        for (int i = 0; i < parameters.length; i++) {
+            if (parameters[i].getName().equals(lockParam)) {
+                return key + ":" + args[i];
+            }
+        }
+
+        //개발자가 어노테이션을 잘못 작성했을 때 에러 발생
+        throw new IllegalArgumentException("lockParam '" + lockParam + "'에 해당하는 파라미터를 찾을 수 없습니다");
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspect.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspect.java
@@ -27,12 +27,22 @@ public class DistributedLockAspect {
     private static final ParameterNameDiscoverer PARAMETER_NAME_DISCOVERER = new DefaultParameterNameDiscoverer();
 
     private final RedissonClient redissonClient;
+    private final LockKeyResolver lockKeyResolver;
 
     @Around("@annotation(com.codeit.team4.deokhugam.global.lock.DistributedLock)")
     public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        DistributedLock distributedLock = signature.getMethod().getAnnotation(DistributedLock.class);
-        String lockKey = buildLockKey(distributedLock, joinPoint);
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String[] paramNames = PARAMETER_NAME_DISCOVERER.getParameterNames(method);
+        String lockKey = lockKeyResolver.resolve(
+                distributedLock.key(),
+                distributedLock.lockParam(),
+                paramNames,
+                joinPoint.getArgs()
+        );
+
         RLock lock = redissonClient.getLock(lockKey);
 
         log.debug("락 획득 시도: {}", lockKey);
@@ -58,34 +68,5 @@ public class DistributedLockAspect {
                 log.debug("락 해제: {}", lockKey);
             }
         }
-    }
-
-    private String buildLockKey(DistributedLock distributedLock, ProceedingJoinPoint joinPoint) {
-        String key = distributedLock.key();
-        String lockParam = distributedLock.lockParam();
-
-        if (lockParam.isEmpty()) {
-            return key;
-        }
-
-        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        Method method = signature.getMethod();
-        String[] names = PARAMETER_NAME_DISCOVERER.getParameterNames(method);
-        Object[] args = joinPoint.getArgs();
-
-        if (names != null) {
-            for (int i = 0; i < names.length; i++) {
-                if (lockParam.equals(names[i])) {
-                    if (args[i] == null) {
-                        //개발자가 키 파라미터를 null로 작성했을 경우 에러 발생
-                        throw new IllegalArgumentException("lockParam '" + lockParam + "' 값이 null입니다");
-                    }
-                    return key + ":" + args[i];
-                }
-            }
-        }
-
-        //개발자가 키 파라미터를 잘못 작성했을 때 에러 발생
-        throw new IllegalArgumentException("lockParam '" + lockParam + "'에 해당하는 파라미터를 찾을 수 없습니다");
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspect.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspect.java
@@ -11,21 +11,23 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Aspect
 @Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
 @RequiredArgsConstructor
 public class DistributedLockAspect {
 
     private final RedissonClient redissonClient;
 
-    @Around("@annotation(distributedLock)")
-    public Object around(
-            ProceedingJoinPoint joinPoint,
-            DistributedLock distributedLock
-    ) throws Throwable {
+    @Around("@annotation(com.codeit.team4.deokhugam.global.lock.DistributedLock)")
+    public Object around(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        DistributedLock distributedLock = signature.getMethod().getAnnotation(DistributedLock.class);
         String lockKey = buildLockKey(distributedLock, joinPoint);
         RLock lock = redissonClient.getLock(lockKey);
 

--- a/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspect.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspect.java
@@ -2,7 +2,7 @@ package com.codeit.team4.deokhugam.global.lock;
 
 import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.global.error.ErrorCode;
-import java.lang.reflect.Parameter;
+import java.lang.reflect.Method;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -11,7 +11,9 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
+import org.springframework.core.DefaultParameterNameDiscoverer;
 import org.springframework.core.Ordered;
+import org.springframework.core.ParameterNameDiscoverer;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -21,6 +23,8 @@ import org.springframework.stereotype.Component;
 @Order(Ordered.HIGHEST_PRECEDENCE)
 @RequiredArgsConstructor
 public class DistributedLockAspect {
+
+    private static final ParameterNameDiscoverer PARAMETER_NAME_DISCOVERER = new DefaultParameterNameDiscoverer();
 
     private final RedissonClient redissonClient;
 
@@ -65,16 +69,23 @@ public class DistributedLockAspect {
         }
 
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        Parameter[] parameters = signature.getMethod().getParameters();
+        Method method = signature.getMethod();
+        String[] names = PARAMETER_NAME_DISCOVERER.getParameterNames(method);
         Object[] args = joinPoint.getArgs();
 
-        for (int i = 0; i < parameters.length; i++) {
-            if (parameters[i].getName().equals(lockParam)) {
-                return key + ":" + args[i];
+        if (names != null) {
+            for (int i = 0; i < names.length; i++) {
+                if (lockParam.equals(names[i])) {
+                    if (args[i] == null) {
+                        //개발자가 키 파라미터를 null로 작성했을 경우 에러 발생
+                        throw new IllegalArgumentException("lockParam '" + lockParam + "' 값이 null입니다");
+                    }
+                    return key + ":" + args[i];
+                }
             }
         }
 
-        //개발자가 어노테이션을 잘못 작성했을 때 에러 발생
+        //개발자가 키 파라미터를 잘못 작성했을 때 에러 발생
         throw new IllegalArgumentException("lockParam '" + lockParam + "'에 해당하는 파라미터를 찾을 수 없습니다");
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspect.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspect.java
@@ -54,7 +54,7 @@ public class DistributedLockAspect {
         );
 
         if (!acquired) {
-            log.debug("락 획득 실패: {}", lockKey);
+            log.warn("락 획득 실패: {}", lockKey);
             throw new BusinessException(ErrorCode.LOCK_ACQUISITION_FAILED, "락 획득 실패: " + lockKey);
         }
 

--- a/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLockException.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/lock/DistributedLockException.java
@@ -1,0 +1,12 @@
+package com.codeit.team4.deokhugam.global.lock;
+
+public class DistributedLockException extends RuntimeException {
+
+    public DistributedLockException(String message) {
+        super(message);
+    }
+
+    public DistributedLockException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/global/lock/LockKeyResolver.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/lock/LockKeyResolver.java
@@ -1,0 +1,70 @@
+package com.codeit.team4.deokhugam.global.lock;
+
+import java.util.StringJoiner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LockKeyResolver {
+
+    private static final int MAX_NESTED_DEPTH = 2;
+
+    public String resolve(String key, String[] lockParams, String[] paramNames, Object[] args) {
+        if (lockParams.length == 0) {
+            return key;
+        }
+
+        StringJoiner joiner = new StringJoiner(":");
+        joiner.add(key);
+
+        for (String lockParam : lockParams) {
+            Object value = resolveValue(lockParam, paramNames, args);
+            joiner.add(String.valueOf(value));
+        }
+
+        return joiner.toString();
+    }
+
+    private Object resolveValue(String expression, String[] names, Object[] args) {
+        String[] parts = expression.split("\\.", MAX_NESTED_DEPTH);
+        String paramName = parts[0];
+
+        Object value = findArgByName(paramName, names, args);
+
+        if (parts.length == MAX_NESTED_DEPTH) {
+            value = getNestedValue(value, parts[1], expression);
+        }
+
+        if (value == null) {
+            throw new DistributedLockException("lockParam '" + expression + "' 값이 null입니다");
+        }
+
+        return value;
+    }
+
+    private Object findArgByName(String paramName, String[] names, Object[] args) {
+        if (names == null) {
+            throw new DistributedLockException("lockParam '" + paramName + "'에 해당하는 파라미터를 찾을 수 없습니다");
+        }
+
+        for (int i = 0; i < names.length; i++) {
+            if (paramName.equals(names[i])) {
+                return args[i];
+            }
+        }
+
+        throw new DistributedLockException("lockParam '" + paramName + "'에 해당하는 파라미터를 찾을 수 없습니다");
+    }
+
+    private Object getNestedValue(Object target, String fieldPath, String expression) {
+        if (target == null) {
+            throw new DistributedLockException("lockParam '" + expression + "' 값이 null입니다");
+        }
+
+        try {
+            return target.getClass().getMethod(fieldPath).invoke(target);
+        } catch (Exception e) {
+            throw new DistributedLockException(
+                    "lockParam '" + expression + "'의 필드에 접근할 수 없습니다", e);
+        }
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/global/lock/LockKeyResolver.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/lock/LockKeyResolver.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class LockKeyResolver {
 
-    private static final int MAX_NESTED_DEPTH = 2;
+    private static final int SPLIT_LIMIT = 2;
 
     public String resolve(String key, String[] lockParams, String[] paramNames, Object[] args) {
         if (lockParams.length == 0) {
@@ -25,12 +25,12 @@ public class LockKeyResolver {
     }
 
     private Object resolveValue(String expression, String[] names, Object[] args) {
-        String[] parts = expression.split("\\.", MAX_NESTED_DEPTH);
+        String[] parts = expression.split("\\.", SPLIT_LIMIT);
         String paramName = parts[0];
 
         Object value = findArgByName(paramName, names, args);
 
-        if (parts.length == MAX_NESTED_DEPTH) {
+        if (parts.length == SPLIT_LIMIT) {
             value = getNestedValue(value, parts[1], expression);
         }
 

--- a/src/test/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspectTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspectTest.java
@@ -153,13 +153,8 @@ class DistributedLockAspectTest {
             CountDownLatch lockAcquired = new CountDownLatch(1);
             CountDownLatch testDone = new CountDownLatch(1);
 
-            Thread holder = new Thread(() -> {
-                try {
-                    testLockService.doWorkWithCallback(99L, lockAcquired);
-                    testDone.await(10, TimeUnit.SECONDS);
-                } catch (InterruptedException ignored) {
-                }
-            });
+            Thread holder = new Thread(() ->
+                    testLockService.doWorkWithCallback(99L, lockAcquired, testDone));
             holder.start();
 
             boolean acquired = lockAcquired.await(5, TimeUnit.SECONDS);
@@ -219,11 +214,11 @@ class DistributedLockAspectTest {
             return "done";
         }
 
-        @DistributedLock(key = "test:slow", lockParam = {"id"}, waitTime = 0, leaseTime = 10)
-        public String doWorkWithCallback(Long id, CountDownLatch lockAcquired) {
+        @DistributedLock(key = "test:slow", lockParam = {"id"}, waitTime = 0, leaseTime = 30)
+        public String doWorkWithCallback(Long id, CountDownLatch lockAcquired, CountDownLatch release) {
             lockAcquired.countDown();
             try {
-                Thread.sleep(5000);
+                release.await(30, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/src/test/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspectTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspectTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.codeit.team4.deokhugam.config.TestContainerConfig;
 import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.global.error.ErrorCode;
+import java.util.UUID;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -50,6 +51,29 @@ class DistributedLockAspectTest {
             String result = testLockService.doWorkWithParam(123L);
 
             assertThat(result).isEqualTo("done:123");
+        }
+
+        @Test
+        @DisplayName("복수 lockParam으로 복합 키 조합 성공")
+        void acquireLockWithMultipleParams() {
+            UUID userId = UUID.randomUUID();
+            UUID bookId = UUID.randomUUID();
+
+            String result = testLockService.doWorkWithMultipleParams(userId, bookId);
+
+            assertThat(result).isEqualTo("done:" + userId + ":" + bookId);
+        }
+
+        @Test
+        @DisplayName("중첩 lockParam으로 객체 필드 키 조합 성공")
+        void acquireLockWithNestedParam() {
+            UUID userId = UUID.randomUUID();
+            UUID bookId = UUID.randomUUID();
+            TestRequest request = new TestRequest(userId, bookId);
+
+            String result = testLockService.doWorkWithNestedParam(request);
+
+            assertThat(result).isEqualTo("done:" + userId + ":" + bookId);
         }
     }
 
@@ -160,19 +184,32 @@ class DistributedLockAspectTest {
         }
     }
 
+    record TestRequest(UUID userId, UUID bookId) {
+    }
+
     static class TestLockService {
 
-        @DistributedLock(key = "test:work", lockParam = "id")
+        @DistributedLock(key = "test:work", lockParam = {"id"})
         public String doWork(Long id) {
             return "done";
         }
 
-        @DistributedLock(key = "test:param", lockParam = "bookId")
+        @DistributedLock(key = "test:param", lockParam = {"bookId"})
         public String doWorkWithParam(Long bookId) {
             return "done:" + bookId;
         }
 
-        @DistributedLock(key = "test:slow", lockParam = "id", waitTime = 0, leaseTime = 5)
+        @DistributedLock(key = "test:multi", lockParam = {"userId", "bookId"})
+        public String doWorkWithMultipleParams(UUID userId, UUID bookId) {
+            return "done:" + userId + ":" + bookId;
+        }
+
+        @DistributedLock(key = "test:nested", lockParam = {"request.userId", "request.bookId"})
+        public String doWorkWithNestedParam(TestRequest request) {
+            return "done:" + request.userId() + ":" + request.bookId();
+        }
+
+        @DistributedLock(key = "test:slow", lockParam = {"id"}, waitTime = 0, leaseTime = 5)
         public String doSlowWork(Long id) {
             try {
                 Thread.sleep(3000);
@@ -182,7 +219,7 @@ class DistributedLockAspectTest {
             return "done";
         }
 
-        @DistributedLock(key = "test:slow", lockParam = "id", waitTime = 0, leaseTime = 10)
+        @DistributedLock(key = "test:slow", lockParam = {"id"}, waitTime = 0, leaseTime = 10)
         public String doWorkWithCallback(Long id, CountDownLatch lockAcquired) {
             lockAcquired.countDown();
             try {

--- a/src/test/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspectTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspectTest.java
@@ -1,0 +1,177 @@
+package com.codeit.team4.deokhugam.global.lock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.codeit.team4.deokhugam.config.TestContainerConfig;
+import com.codeit.team4.deokhugam.global.error.BusinessException;
+import com.codeit.team4.deokhugam.global.error.ErrorCode;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Service;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(TestContainerConfig.class)
+class DistributedLockAspectTest {
+
+    @Autowired
+    private TestLockService testLockService;
+
+    @Nested
+    @DisplayName("단일 요청 락 획득")
+    class SingleLock {
+
+        @Test
+        @DisplayName("락 획득 성공")
+        void acquireLockSuccess() {
+            String result = testLockService.doWork(1L);
+
+            assertThat(result).isEqualTo("done");
+        }
+
+        @Test
+        @DisplayName("lockParam으로 키 조합 성공")
+        void acquireLockWithParam() {
+            String result = testLockService.doWorkWithParam(123L);
+
+            assertThat(result).isEqualTo("done:123");
+        }
+    }
+
+    @Nested
+    @DisplayName("동시 요청 락 경합")
+    class ConcurrentLock {
+
+        @Test
+        @DisplayName("같은 키로 동시 요청 시 하나만 실행 성공")
+        void concurrentSameKeyOnlyOneSucceeds() throws InterruptedException {
+            int threadCount = 5;
+            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+            AtomicInteger successCount = new AtomicInteger(0);
+            AtomicInteger failCount = new AtomicInteger(0);
+
+            for (int i = 0; i < threadCount; i++) {
+                executor.submit(() -> {
+                    try {
+                        testLockService.doSlowWork(1L);
+                        successCount.incrementAndGet();
+                    } catch (BusinessException e) {
+                        failCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            latch.await(10, TimeUnit.SECONDS);
+            executor.shutdown();
+
+            assertThat(successCount.get()).isEqualTo(1);
+            assertThat(failCount.get()).isEqualTo(threadCount - 1);
+        }
+
+        @Test
+        @DisplayName("다른 키로 동시 요청 시 모두 실행 성공")
+        void concurrentDifferentKeysAllSucceed() throws InterruptedException {
+            int threadCount = 3;
+            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+            AtomicInteger successCount = new AtomicInteger(0);
+
+            for (int i = 0; i < threadCount; i++) {
+                long id = i + 1;
+                executor.submit(() -> {
+                    try {
+                        testLockService.doSlowWork(id);
+                        successCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+
+            latch.await(10, TimeUnit.SECONDS);
+            executor.shutdown();
+
+            assertThat(successCount.get()).isEqualTo(threadCount);
+        }
+    }
+
+    @Nested
+    @DisplayName("락 획득 실패")
+    class LockFail {
+
+        @Test
+        @DisplayName("waitTime 내에 락 획득 실패 시 BusinessException 발생")
+        void throwsBusinessExceptionWhenLockFails() throws InterruptedException {
+            CountDownLatch lockAcquired = new CountDownLatch(1);
+            CountDownLatch testDone = new CountDownLatch(1);
+
+            Thread holder = new Thread(() -> {
+                try {
+                    testLockService.doWorkWithCallback(99L, lockAcquired);
+                    testDone.await(10, TimeUnit.SECONDS);
+                } catch (InterruptedException ignored) {
+                }
+            });
+            holder.start();
+
+            lockAcquired.await(5, TimeUnit.SECONDS);
+
+            assertThatThrownBy(() -> testLockService.doSlowWork(99L))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.LOCK_ACQUISITION_FAILED));
+
+            testDone.countDown();
+            holder.join(5000);
+        }
+    }
+
+    @Service
+    static class TestLockService {
+
+        @DistributedLock(key = "test:work", lockParam = "id")
+        public String doWork(Long id) {
+            return "done";
+        }
+
+        @DistributedLock(key = "test:param", lockParam = "bookId")
+        public String doWorkWithParam(Long bookId) {
+            return "done:" + bookId;
+        }
+
+        @DistributedLock(key = "test:slow", lockParam = "id", waitTime = 0, leaseTime = 5)
+        public String doSlowWork(Long id) {
+            try {
+                Thread.sleep(3000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return "done";
+        }
+
+        @DistributedLock(key = "test:slow", lockParam = "id", waitTime = 0, leaseTime = 10)
+        public String doWorkWithCallback(Long id, CountDownLatch lockAcquired) {
+            lockAcquired.countDown();
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return "done";
+        }
+    }
+}

--- a/src/test/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspectTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/global/lock/DistributedLockAspectTest.java
@@ -6,6 +6,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.codeit.team4.deokhugam.config.TestContainerConfig;
 import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.global.error.ErrorCode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -16,13 +19,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.stereotype.Service;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-@Import(TestContainerConfig.class)
+@Import({TestContainerConfig.class, DistributedLockAspectTest.TestLockConfig.class})
 class DistributedLockAspectTest {
 
     @Autowired
@@ -75,9 +79,10 @@ class DistributedLockAspectTest {
                 });
             }
 
-            latch.await(10, TimeUnit.SECONDS);
+            boolean completed = latch.await(10, TimeUnit.SECONDS);
             executor.shutdown();
 
+            assertThat(completed).as("모든 작업이 제한 시간 내 완료되어야 함").isTrue();
             assertThat(successCount.get()).isEqualTo(1);
             assertThat(failCount.get()).isEqualTo(threadCount - 1);
         }
@@ -89,6 +94,7 @@ class DistributedLockAspectTest {
             ExecutorService executor = Executors.newFixedThreadPool(threadCount);
             CountDownLatch latch = new CountDownLatch(threadCount);
             AtomicInteger successCount = new AtomicInteger(0);
+            List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
 
             for (int i = 0; i < threadCount; i++) {
                 long id = i + 1;
@@ -96,15 +102,19 @@ class DistributedLockAspectTest {
                     try {
                         testLockService.doSlowWork(id);
                         successCount.incrementAndGet();
+                    } catch (Throwable t) {
+                        failures.add(t);
                     } finally {
                         latch.countDown();
                     }
                 });
             }
 
-            latch.await(10, TimeUnit.SECONDS);
+            boolean completed = latch.await(10, TimeUnit.SECONDS);
             executor.shutdown();
 
+            assertThat(completed).as("모든 작업이 제한 시간 내 완료되어야 함").isTrue();
+            assertThat(failures).as("예상치 못한 예외가 발생하지 않아야 함").isEmpty();
             assertThat(successCount.get()).isEqualTo(threadCount);
         }
     }
@@ -128,7 +138,8 @@ class DistributedLockAspectTest {
             });
             holder.start();
 
-            lockAcquired.await(5, TimeUnit.SECONDS);
+            boolean acquired = lockAcquired.await(5, TimeUnit.SECONDS);
+            assertThat(acquired).as("락 획득이 제한 시간 내 완료되어야 함").isTrue();
 
             assertThatThrownBy(() -> testLockService.doSlowWork(99L))
                     .isInstanceOf(BusinessException.class)
@@ -140,7 +151,15 @@ class DistributedLockAspectTest {
         }
     }
 
-    @Service
+    @TestConfiguration
+    static class TestLockConfig {
+
+        @Bean
+        public TestLockService testLockService() {
+            return new TestLockService();
+        }
+    }
+
     static class TestLockService {
 
         @DistributedLock(key = "test:work", lockParam = "id")

--- a/src/test/java/com/codeit/team4/deokhugam/global/lock/LockKeyResolverTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/global/lock/LockKeyResolverTest.java
@@ -1,0 +1,138 @@
+package com.codeit.team4.deokhugam.global.lock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class LockKeyResolverTest {
+
+    private final LockKeyResolver resolver = new LockKeyResolver();
+
+    @Nested
+    @DisplayName("키 생성 성공")
+    class Resolve {
+
+        @Test
+        @DisplayName("lockParam 없으면 key만 반환")
+        void keyOnly() {
+            String result = resolver.resolve("dashboard-batch", new String[]{}, null, null);
+
+            assertThat(result).isEqualTo("dashboard-batch");
+        }
+
+        @Test
+        @DisplayName("단일 lockParam으로 키 조합 성공")
+        void singleParam() {
+            String result = resolver.resolve(
+                    "deokhugam:book",
+                    new String[]{"bookId"},
+                    new String[]{"bookId"},
+                    new Object[]{123L}
+            );
+
+            assertThat(result).isEqualTo("deokhugam:book:123");
+        }
+
+        @Test
+        @DisplayName("복수 lockParam으로 복합 키 조합 성공")
+        void multipleParams() {
+            UUID userId = UUID.randomUUID();
+            UUID bookId = UUID.randomUUID();
+
+            String result = resolver.resolve(
+                    "deokhugam:review",
+                    new String[]{"userId", "bookId"},
+                    new String[]{"userId", "bookId"},
+                    new Object[]{userId, bookId}
+            );
+
+            assertThat(result).isEqualTo("deokhugam:review:" + userId + ":" + bookId);
+        }
+
+        @Test
+        @DisplayName("중첩 lockParam으로 객체 필드 접근 성공")
+        void nestedParam() {
+            UUID userId = UUID.randomUUID();
+            UUID bookId = UUID.randomUUID();
+            TestRequest request = new TestRequest(userId, bookId);
+
+            String result = resolver.resolve(
+                    "deokhugam:review",
+                    new String[]{"request.userId", "request.bookId"},
+                    new String[]{"request"},
+                    new Object[]{request}
+            );
+
+            assertThat(result).isEqualTo("deokhugam:review:" + userId + ":" + bookId);
+        }
+    }
+
+    @Nested
+    @DisplayName("키 생성 실패")
+    class ResolveFail {
+
+        @Test
+        @DisplayName("존재하지 않는 파라미터 이름이면 DistributedLockException 발생")
+        void paramNotFound() {
+            assertThatThrownBy(() -> resolver.resolve(
+                    "test",
+                    new String[]{"invalid"},
+                    new String[]{"bookId"},
+                    new Object[]{1L}
+            )).isInstanceOf(DistributedLockException.class);
+        }
+
+        @Test
+        @DisplayName("파라미터 값이 null이면 DistributedLockException 발생")
+        void paramValueNull() {
+            assertThatThrownBy(() -> resolver.resolve(
+                    "test",
+                    new String[]{"bookId"},
+                    new String[]{"bookId"},
+                    new Object[]{null}
+            )).isInstanceOf(DistributedLockException.class);
+        }
+
+        @Test
+        @DisplayName("중첩 대상 객체가 null이면 DistributedLockException 발생")
+        void nestedTargetNull() {
+            assertThatThrownBy(() -> resolver.resolve(
+                    "test",
+                    new String[]{"request.userId"},
+                    new String[]{"request"},
+                    new Object[]{null}
+            )).isInstanceOf(DistributedLockException.class);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 필드 접근이면 DistributedLockException 발생")
+        void nestedFieldNotFound() {
+            TestRequest request = new TestRequest(UUID.randomUUID(), UUID.randomUUID());
+
+            assertThatThrownBy(() -> resolver.resolve(
+                    "test",
+                    new String[]{"request.invalid"},
+                    new String[]{"request"},
+                    new Object[]{request}
+            )).isInstanceOf(DistributedLockException.class);
+        }
+
+        @Test
+        @DisplayName("paramNames가 null이면 DistributedLockException 발생")
+        void paramNamesNull() {
+            assertThatThrownBy(() -> resolver.resolve(
+                    "test",
+                    new String[]{"bookId"},
+                    null,
+                    new Object[]{1L}
+            )).isInstanceOf(DistributedLockException.class);
+        }
+    }
+
+    record TestRequest(UUID userId, UUID bookId) {
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- closes #171

## 작업 내용
- 다중 인스턴스 환경에서 동시성 제어를 위한 Redis 기반 분산 락 컴포넌트 구현
- javadocs 로 사용 방법 문서화

## 변경 사항
  - Redisson 의존성 추가                                                                                                                                                                                                                                                  
  - `@DistributedLock` 어노테이션 생성 (key, lockParam, waitTime, leaseTime, timeUnit)                                                                                                                                                                                  
  - `DistributedLockAspect` AOP 구현 (Redisson RLock 기반 락 획득/해제)                                                                                                                                                                                                   
  - `ErrorCode.LOCK_ACQUISITION_FAILED` 추가                                                                                                                                                                                                                              
  - 동시성 테스트 작성 (같은 키 경합, 다른 키 독립 실행, 락 실패 검증)                                                                                                                                                                                                    

## 테스트 내용
- [x] 테스트 코드 작성
- [ ] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Redis 기반 분산 잠금 지원을 추가하여 동일 리소스에 대한 동시 처리를 방지합니다. 잠금 획득 실패 시 충돌(409) 오류와 안내 메시지를 반환합니다.

* **테스트**
  * 잠금 키 계산, 중복/다중 파라미터 및 중첩 필드 처리, 동시성 시나리오 및 잠금 획득 실패 타이밍에 대한 통합/단위 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->