### PR TITLE
feat: 댓글 단건 조회 & 목록 조회 및 커서 페이지네이션 구현

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/comment/controller/CommentController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/controller/CommentController.java
@@ -3,17 +3,22 @@ package com.codeit.team4.deokhugam.comment.controller;
 import com.codeit.team4.deokhugam.comment.controller.api.CommentApi;
 import com.codeit.team4.deokhugam.comment.dto.CommentCreateRequest;
 import com.codeit.team4.deokhugam.comment.dto.CommentResponse;
+import com.codeit.team4.deokhugam.comment.dto.CommentSearchRequestParam;
 import com.codeit.team4.deokhugam.comment.dto.CommentUpdateRequest;
+import com.codeit.team4.deokhugam.comment.service.CommentQueryService;
 import com.codeit.team4.deokhugam.comment.service.CommentService;
 import com.codeit.team4.deokhugam.global.annotation.LoginUser;
 import com.codeit.team4.deokhugam.global.dto.DeokhugamUser;
+import com.codeit.team4.deokhugam.global.response.PageResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController implements CommentApi {
 
     private final CommentService commentService;
+    private final CommentQueryService commentQueryService;
 
     @PostMapping
     public ResponseEntity<CommentResponse> createComment(
@@ -75,5 +81,20 @@ public class CommentController implements CommentApi {
         commentService.hardDeleteComment(commentId, loginUser.userId());
 
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{commentId}")
+    public ResponseEntity<CommentResponse> getComment(
+            @PathVariable UUID commentId) {
+        log.info("댓글 단건 조회 요청: commentId={}", commentId);
+        return ResponseEntity.ok(commentQueryService.getComment(commentId));
+    }
+
+    @GetMapping
+    public ResponseEntity<PageResponse<CommentResponse>> getComments(
+            @Valid @ParameterObject CommentSearchRequestParam param) {
+        log.info("댓글 목록 조회 요청: reviewId={}, direction={}, limit={}",
+                param.reviewId(), param.direction(), param.limit());
+        return ResponseEntity.ok(commentQueryService.getComments(param));
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/controller/api/CommentApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/controller/api/CommentApi.java
@@ -2,10 +2,12 @@ package com.codeit.team4.deokhugam.comment.controller.api;
 
 import com.codeit.team4.deokhugam.comment.dto.CommentCreateRequest;
 import com.codeit.team4.deokhugam.comment.dto.CommentResponse;
+import com.codeit.team4.deokhugam.comment.dto.CommentSearchRequestParam;
 import com.codeit.team4.deokhugam.comment.dto.CommentUpdateRequest;
 import com.codeit.team4.deokhugam.global.annotation.LoginUser;
 import com.codeit.team4.deokhugam.global.dto.DeokhugamUser;
 import com.codeit.team4.deokhugam.global.error.ErrorResponse;
+import com.codeit.team4.deokhugam.global.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -16,6 +18,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.UUID;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -115,6 +118,36 @@ public interface CommentApi {
     ResponseEntity<Void> hardDeleteComment(
             @Parameter(description = "댓글 ID", required = true) @PathVariable UUID commentId,
             @LoginUser DeokhugamUser loginUser
+    );
+
+    @Operation(summary = "댓글 단건 조회", description = "특정 댓글의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "댓글 조회 성공",
+                    content = @Content(schema = @Schema(implementation = CommentResponse.class))),
+            @ApiResponse(responseCode = "404", description = "댓글 정보 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<CommentResponse> getComment(
+            @Parameter(description = "댓글 ID", required = true,
+                    example = "123e4567-e89b-12d3-a456-426614174000")
+            @PathVariable UUID commentId
+    );
+
+    @Operation(summary = "리뷰 댓글 목록 조회", description = "특정 리뷰에 달린 댓글 목록을 시간순으로 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "댓글 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = PageResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (정렬 방향 오류, 페이지네이션 파라미터 오류, 리뷰 ID 누락)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "리뷰 정보 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<PageResponse<CommentResponse>> getComments(
+            @ParameterObject CommentSearchRequestParam param
     );
 
 }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/controller/api/CommentApi.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/controller/api/CommentApi.java
@@ -120,7 +120,7 @@ public interface CommentApi {
             @LoginUser DeokhugamUser loginUser
     );
 
-    @Operation(summary = "댓글 단건 조회", description = "특정 댓글의 상세 정보를 조회합니다.")
+    @Operation(summary = "댓글 정보 상세 조회", description = "특정 댓글의 상세 정보를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "댓글 조회 성공",
                     content = @Content(schema = @Schema(implementation = CommentResponse.class))),

--- a/src/main/java/com/codeit/team4/deokhugam/comment/dto/CommentSearchRequestParam.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/dto/CommentSearchRequestParam.java
@@ -1,0 +1,37 @@
+package com.codeit.team4.deokhugam.comment.dto;
+
+import com.codeit.team4.deokhugam.global.response.SortDirection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
+import java.util.UUID;
+
+@Schema(description = "댓글 목록 조회 요청")
+public record CommentSearchRequestParam(
+
+        @Schema(description = "리뷰 ID", required = true)
+        @NotNull(message = "리뷰 ID는 필수입니다.")
+        UUID reviewId,
+
+        @Schema(description = "정렬 방향 (ASC | DESC)", defaultValue = "DESC")
+        SortDirection direction,
+
+        @Schema(description = "커서 페이지네이션 커서")
+        String cursor,
+
+        @Schema(description = "보조 커서 (createdAt)")
+        Instant after,
+
+        @Schema(description = "페이지 크기", defaultValue = "50")
+        @Min(1) @Max(100)
+        Integer limit
+) {
+    private static final int DEFAULT_LIMIT = 50;
+
+    public CommentSearchRequestParam {
+        if (direction == null) direction = SortDirection.DESC;
+        if (limit == null) limit = DEFAULT_LIMIT;
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/comment/dto/CommentSearchRequestParam.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/dto/CommentSearchRequestParam.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Schema(description = "댓글 목록 조회 요청")
 public record CommentSearchRequestParam(
 
-        @Schema(description = "리뷰 ID", required = true)
+        @Schema(description = "리뷰 ID", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotNull(message = "리뷰 ID는 필수입니다.")
         UUID reviewId,
 
@@ -28,10 +28,15 @@ public record CommentSearchRequestParam(
         @Min(1) @Max(100)
         Integer limit
 ) {
+
     private static final int DEFAULT_LIMIT = 50;
 
     public CommentSearchRequestParam {
-        if (direction == null) direction = SortDirection.DESC;
-        if (limit == null) limit = DEFAULT_LIMIT;
+        if (direction == null) {
+            direction = SortDirection.DESC;
+        }
+        if (limit == null) {
+            limit = DEFAULT_LIMIT;
+        }
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/mapper/CommentMapper.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/mapper/CommentMapper.java
@@ -2,6 +2,7 @@ package com.codeit.team4.deokhugam.comment.mapper;
 
 import com.codeit.team4.deokhugam.comment.dto.CommentResponse;
 import com.codeit.team4.deokhugam.comment.entity.Comment;
+import com.codeit.team4.deokhugam.comment.model.CommentModel;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -12,5 +13,7 @@ public interface CommentMapper {
     @Mapping(source = "review.id", target = "reviewId")
     @Mapping(source = "user.nickname", target = "userNickname")
     CommentResponse toResponse(Comment comment);
+
+    CommentResponse toResponse(CommentModel model);
 
 }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/model/CommentModel.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/model/CommentModel.java
@@ -1,0 +1,44 @@
+package com.codeit.team4.deokhugam.comment.model;
+
+import static com.codeit.team4.deokhugam.jooq.tables.Comments.COMMENTS;
+import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.jooq.Field;
+import org.jooq.Record;
+
+public record CommentModel(
+        UUID id,
+        UUID reviewId,
+        UUID userId,
+        String userNickname,
+        String content,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static List<Field<?>> toSelectedFields() {
+        return List.of(
+                COMMENTS.ID,
+                COMMENTS.REVIEW_ID,
+                COMMENTS.USER_ID,
+                USERS.NICKNAME,
+                COMMENTS.CONTENT,
+                COMMENTS.CREATED_AT,
+                COMMENTS.UPDATED_AT
+        );
+    }
+
+    public static CommentModel fromRecord(Record rec) {
+        return new CommentModel(
+                rec.get(COMMENTS.ID),
+                rec.get(COMMENTS.REVIEW_ID),
+                rec.get(COMMENTS.USER_ID),
+                rec.get(USERS.NICKNAME),
+                rec.get(COMMENTS.CONTENT),
+                rec.get(COMMENTS.CREATED_AT).toInstant(),
+                rec.get(COMMENTS.UPDATED_AT).toInstant()
+        );
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentQueryService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentQueryService.java
@@ -1,0 +1,135 @@
+package com.codeit.team4.deokhugam.comment.service;
+
+import static com.codeit.team4.deokhugam.jooq.tables.Comments.COMMENTS;
+import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
+
+import com.codeit.team4.deokhugam.comment.dto.CommentResponse;
+import com.codeit.team4.deokhugam.comment.dto.CommentSearchRequestParam;
+import com.codeit.team4.deokhugam.comment.mapper.CommentMapper;
+import com.codeit.team4.deokhugam.comment.model.CommentModel;
+import com.codeit.team4.deokhugam.global.error.BusinessException;
+import com.codeit.team4.deokhugam.global.error.ErrorCode;
+import com.codeit.team4.deokhugam.global.response.PageResponse;
+import com.codeit.team4.deokhugam.global.response.SortDirection;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jooq.Condition;
+import org.jooq.DSLContext;
+import org.jooq.SortField;
+import org.jooq.impl.DSL;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentQueryService {
+
+    private final DSLContext dsl;
+    private final CommentMapper commentMapper;
+
+    // 댓글 단건 조회
+    public CommentResponse getComment(UUID commentId) {
+        CommentModel model = dsl
+                .select(CommentModel.toSelectedFields())
+                .from(COMMENTS)
+                .join(USERS).on(COMMENTS.USER_ID.eq(USERS.ID))
+                .where(COMMENTS.ID.eq(commentId)
+                        .and(COMMENTS.DELETED_AT.isNull()))
+                .fetchOne(CommentModel::fromRecord);
+
+        if (model == null) {
+            throw new BusinessException(ErrorCode.COMMENT_NOT_FOUND, "commentId=" + commentId);
+        }
+
+        log.info("댓글 단건 조회 완료: commentId={}", commentId);
+        return commentMapper.toResponse(model);
+    }
+
+    // 댓글 목록 조회
+    public PageResponse<CommentResponse> getComments(CommentSearchRequestParam param) {
+        validateCursorParam(param);
+
+        boolean isAsc = SortDirection.ASC == param.direction();
+
+        Condition condition = COMMENTS.REVIEW_ID.eq(param.reviewId())
+                .and(COMMENTS.DELETED_AT.isNull())
+                .and(buildCursorCondition(param.after(), isAsc));
+
+        SortField<?> sortField = isAsc
+                ? COMMENTS.CREATED_AT.asc()
+                : COMMENTS.CREATED_AT.desc();
+
+        List<CommentModel> results = dsl
+                .select(CommentModel.toSelectedFields())
+                .from(COMMENTS)
+                .join(USERS).on(COMMENTS.USER_ID.eq(USERS.ID))
+                .where(condition)
+                .orderBy(sortField)
+                .limit(param.limit() + 1)   // hasNext 판단을 위해 +1 조회
+                .fetch(CommentModel::fromRecord);
+
+        boolean hasNext = results.size() > param.limit();
+        List<CommentModel> content = hasNext
+                ? results.subList(0, param.limit())
+                : results;
+
+        // 다음 페이지 커서 추출
+        String nextCursor = null;
+        Instant nextAfter = null;
+        if (hasNext && !content.isEmpty()) {
+            CommentModel last = content.get(content.size() - 1);
+            nextCursor = last.createdAt().toString();
+            nextAfter = last.createdAt();
+        }
+
+        long totalElements = countActiveComments(param.reviewId());
+
+        List<CommentResponse> responses = content.stream()
+                .map(commentMapper::toResponse)
+                .toList();
+
+        log.info("댓글 목록 조회 완료: reviewId={}, size={}", param.reviewId(), responses.size());
+
+        return new PageResponse<>(responses, nextCursor, nextAfter, param.limit(), totalElements, hasNext);
+    }
+
+    // ===== private =====
+
+    // cursor와 after는 반드시 함께 제공되거나 함께 null
+    private void validateCursorParam(CommentSearchRequestParam param) {
+        if ((param.cursor() == null) != (param.after() == null)) {
+            throw new BusinessException(
+                    ErrorCode.INVALID_INPUT,
+                    "cursor와 after는 함께 제공되어야 합니다. cursor=" + param.cursor() + ", after=" + param.after()
+            );
+        }
+    }
+
+    private Condition buildCursorCondition(Instant after, boolean isAsc) {
+        if (after == null) {
+            return DSL.noCondition();
+        }
+        OffsetDateTime afterOffset = after.atOffset(ZoneOffset.UTC);
+        return isAsc
+                ? COMMENTS.CREATED_AT.gt(afterOffset)
+                : COMMENTS.CREATED_AT.lt(afterOffset);
+    }
+
+    private long countActiveComments(UUID reviewId) {
+        return Optional.ofNullable(
+                dsl.selectCount()
+                        .from(COMMENTS)
+                        .where(COMMENTS.REVIEW_ID.eq(reviewId)
+                                .and(COMMENTS.DELETED_AT.isNull()))
+                        .fetchOne(0, Long.class)
+        ).orElse(0L);
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentQueryService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentQueryService.java
@@ -88,7 +88,7 @@ public class CommentQueryService {
         Instant nextAfter = null;
         if (hasNext && !content.isEmpty()) {
             CommentModel last = content.get(content.size() - 1);
-            nextCursor = last.createdAt().toString();
+            nextCursor = last.id().toString();
             nextAfter = last.createdAt();
         }
 

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentQueryService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentQueryService.java
@@ -98,7 +98,8 @@ public class CommentQueryService {
 
         log.info("댓글 목록 조회 완료: reviewId={}, size={}", param.reviewId(), responses.size());
 
-        return new PageResponse<>(responses, nextCursor, nextAfter, param.limit(), totalElements, hasNext);
+        return new PageResponse<>(responses, nextCursor, nextAfter, param.limit(), totalElements,
+                hasNext);
     }
 
     // ===== private =====
@@ -108,7 +109,8 @@ public class CommentQueryService {
         if ((param.cursor() == null) != (param.after() == null)) {
             throw new BusinessException(
                     ErrorCode.INVALID_INPUT,
-                    "cursor와 after는 함께 제공되어야 합니다. cursor=" + param.cursor() + ", after=" + param.after()
+                    "cursor와 after는 함께 제공되어야 합니다. cursor=" + param.cursor() + ", after="
+                            + param.after()
             );
         }
     }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentQueryService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentQueryService.java
@@ -1,6 +1,7 @@
 package com.codeit.team4.deokhugam.comment.service;
 
 import static com.codeit.team4.deokhugam.jooq.tables.Comments.COMMENTS;
+import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
 import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
 
 import com.codeit.team4.deokhugam.comment.dto.CommentResponse;
@@ -61,18 +62,19 @@ public class CommentQueryService {
 
         Condition condition = COMMENTS.REVIEW_ID.eq(param.reviewId())
                 .and(COMMENTS.DELETED_AT.isNull())
-                .and(buildCursorCondition(param.after(), isAsc));
+                .and(buildCursorCondition(param, isAsc));
 
         SortField<?> sortField = isAsc
-                ? COMMENTS.CREATED_AT.asc()
-                : COMMENTS.CREATED_AT.desc();
+                ? COMMENTS.CREATED_AT.asc() : COMMENTS.CREATED_AT.desc();
+        SortField<?> tieBreaker = isAsc
+                ? COMMENTS.ID.asc() : COMMENTS.ID.desc();
 
         List<CommentModel> results = dsl
                 .select(CommentModel.toSelectedFields())
                 .from(COMMENTS)
                 .join(USERS).on(COMMENTS.USER_ID.eq(USERS.ID))
                 .where(condition)
-                .orderBy(sortField)
+                .orderBy(sortField, tieBreaker)
                 .limit(param.limit() + 1)   // hasNext 판단을 위해 +1 조회
                 .fetch(CommentModel::fromRecord);
 
@@ -115,23 +117,24 @@ public class CommentQueryService {
         }
     }
 
-    private Condition buildCursorCondition(Instant after, boolean isAsc) {
-        if (after == null) {
+    private Condition buildCursorCondition(CommentSearchRequestParam param, boolean isAsc) {
+        if (param.after() == null || param.cursor() == null) {
             return DSL.noCondition();
         }
-        OffsetDateTime afterOffset = after.atOffset(ZoneOffset.UTC);
+        OffsetDateTime afterOffset = param.after().atOffset(ZoneOffset.UTC);
+        UUID cursorId = UUID.fromString(param.cursor());
+
         return isAsc
-                ? COMMENTS.CREATED_AT.gt(afterOffset)
-                : COMMENTS.CREATED_AT.lt(afterOffset);
+                ? DSL.row(COMMENTS.CREATED_AT, COMMENTS.ID).gt(afterOffset, cursorId)
+                : DSL.row(COMMENTS.CREATED_AT, COMMENTS.ID).lt(afterOffset, cursorId);
     }
 
     private long countActiveComments(UUID reviewId) {
         return Optional.ofNullable(
-                dsl.selectCount()
-                        .from(COMMENTS)
-                        .where(COMMENTS.REVIEW_ID.eq(reviewId)
-                                .and(COMMENTS.DELETED_AT.isNull()))
-                        .fetchOne(0, Long.class)
+                dsl.select(REVIEWS.COMMENT_COUNT)
+                        .from(REVIEWS)
+                        .where(REVIEWS.ID.eq(reviewId))
+                        .fetchOneInto(Long.class)
         ).orElse(0L);
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentQueryService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentQueryService.java
@@ -92,7 +92,7 @@ public class CommentQueryService {
             nextAfter = last.createdAt();
         }
 
-        long totalElements = countActiveComments(param.reviewId());
+        long totalElements = fetchReviewCommentCount(param.reviewId());
 
         List<CommentResponse> responses = content.stream()
                 .map(commentMapper::toResponse)
@@ -122,14 +122,22 @@ public class CommentQueryService {
             return DSL.noCondition();
         }
         OffsetDateTime afterOffset = param.after().atOffset(ZoneOffset.UTC);
-        UUID cursorId = UUID.fromString(param.cursor());
+        UUID cursorId;
+        try {
+            cursorId = UUID.fromString(param.cursor());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(
+                    ErrorCode.INVALID_INPUT,
+                    "cursor는 UUID 형식이어야 합니다. cursor=" + param.cursor()
+            );
+        }
 
         return isAsc
                 ? DSL.row(COMMENTS.CREATED_AT, COMMENTS.ID).gt(afterOffset, cursorId)
                 : DSL.row(COMMENTS.CREATED_AT, COMMENTS.ID).lt(afterOffset, cursorId);
     }
 
-    private long countActiveComments(UUID reviewId) {
+    private long fetchReviewCommentCount(UUID reviewId) {
         return Optional.ofNullable(
                 dsl.select(REVIEWS.COMMENT_COUNT)
                         .from(REVIEWS)

--- a/src/test/java/com/codeit/team4/deokhugam/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/controller/CommentControllerTest.java
@@ -573,7 +573,8 @@ class CommentControllerTest {
         // when & then
         mockMvc.perform(get("/api/comments"))
                 .andDo(print())
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").exists());
     }
 
     @Test

--- a/src/test/java/com/codeit/team4/deokhugam/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/controller/CommentControllerTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.codeit.team4.deokhugam.comment.dto.CommentCreateRequest;
 import com.codeit.team4.deokhugam.comment.dto.CommentResponse;
 import com.codeit.team4.deokhugam.comment.dto.CommentUpdateRequest;
+import com.codeit.team4.deokhugam.comment.service.CommentQueryService;
 import com.codeit.team4.deokhugam.comment.service.CommentService;
 import com.codeit.team4.deokhugam.global.config.AppProperties;
 import com.codeit.team4.deokhugam.global.error.BusinessException;
@@ -50,6 +51,9 @@ class CommentControllerTest {
 
     @MockitoBean
     private UserService userService;
+
+    @MockitoBean
+    private CommentQueryService commentQueryService;
 
     @Test
     @DisplayName("댓글 등록 성공")

--- a/src/test/java/com/codeit/team4/deokhugam/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/controller/CommentControllerTest.java
@@ -11,19 +11,23 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 import com.codeit.team4.deokhugam.comment.dto.CommentCreateRequest;
 import com.codeit.team4.deokhugam.comment.dto.CommentResponse;
+import com.codeit.team4.deokhugam.comment.dto.CommentSearchRequestParam;
 import com.codeit.team4.deokhugam.comment.dto.CommentUpdateRequest;
 import com.codeit.team4.deokhugam.comment.service.CommentQueryService;
 import com.codeit.team4.deokhugam.comment.service.CommentService;
 import com.codeit.team4.deokhugam.global.config.AppProperties;
 import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.global.error.ErrorCode;
+import com.codeit.team4.deokhugam.global.response.PageResponse;
 import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -410,6 +414,227 @@ class CommentControllerTest {
         // when & then
         mockMvc.perform(delete("/api/comments/{commentId}/hard", commentId)
                         .header("Deokhugam-Request-User-ID", userId.toString()))
+                .andDo(print())
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.errorCode").value("INTERNAL_SERVER_ERROR"));
+    }
+
+    @Test
+    @DisplayName("댓글 단건 조회 성공")
+    void getComment_Success() throws Exception {
+        // given
+        UUID commentId = UUID.randomUUID();
+        UUID reviewId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        Instant now = Instant.now();
+
+        CommentResponse response = new CommentResponse(
+                commentId,
+                "좋은 리뷰입니다",
+                userId,
+                reviewId,
+                "테스트닉네임",
+                now,
+                now
+        );
+
+        given(commentQueryService.getComment(commentId)).willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/comments/{commentId}", commentId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(commentId.toString()))
+                .andExpect(jsonPath("$.reviewId").value(reviewId.toString()))
+                .andExpect(jsonPath("$.userId").value(userId.toString()))
+                .andExpect(jsonPath("$.userNickname").value("테스트닉네임"))
+                .andExpect(jsonPath("$.content").value("좋은 리뷰입니다"))
+                .andExpect(jsonPath("$.createdAt").exists())
+                .andExpect(jsonPath("$.updatedAt").exists());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글 단건 조회 실패")
+    void getComment_Fail_404_NotFound() throws Exception {
+        // given
+        UUID commentId = UUID.randomUUID();
+
+        given(commentQueryService.getComment(commentId))
+                .willThrow(new BusinessException(ErrorCode.COMMENT_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/comments/{commentId}", commentId))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value("COMMENT_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("서버 내부 오류로 인한 댓글 단건 조회 실패")
+    void getComment_Fail_500_InternalServerError() throws Exception {
+        // given
+        UUID commentId = UUID.randomUUID();
+
+        given(commentQueryService.getComment(commentId))
+                .willThrow(new RuntimeException("DB Connection Timeout"));
+
+        // when & then
+        mockMvc.perform(get("/api/comments/{commentId}", commentId))
+                .andDo(print())
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.errorCode").value("INTERNAL_SERVER_ERROR"));
+    }
+
+
+    @Test
+    @DisplayName("댓글 목록 조회 성공")
+    void getComments_Success() throws Exception {
+        // given
+        UUID reviewId = UUID.randomUUID();
+        UUID commentId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        Instant now = Instant.now();
+
+        CommentResponse commentResponse = new CommentResponse(
+                commentId, "좋은 리뷰입니다", userId, reviewId, "테스트닉네임", now, now
+        );
+
+        PageResponse<CommentResponse> pageResponse = new PageResponse<>(
+                List.of(commentResponse),
+                null,
+                null,
+                50,
+                1L,
+                false
+        );
+
+        given(commentQueryService.getComments(any(CommentSearchRequestParam.class)))
+                .willReturn(pageResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/comments")
+                        .param("reviewId", reviewId.toString()))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(commentId.toString()))
+                .andExpect(jsonPath("$.content[0].reviewId").value(reviewId.toString()))
+                .andExpect(jsonPath("$.content[0].userId").value(userId.toString()))
+                .andExpect(jsonPath("$.content[0].userNickname").value("테스트닉네임"))
+                .andExpect(jsonPath("$.content[0].content").value("좋은 리뷰입니다"))
+                .andExpect(jsonPath("$.hasNext").value(false))
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.size").value(50));
+    }
+
+    @Test
+    @DisplayName("커서와 페이지 정보가 있는 댓글 목록 조회 성공")
+    void getComments_Success_WithNextCursor() throws Exception {
+        // given
+        UUID reviewId = UUID.randomUUID();
+        Instant now = Instant.now();
+
+        // 다음 페이지가 있는 상황
+        PageResponse<CommentResponse> pageResponse = new PageResponse<>(
+                List.of(
+                        new CommentResponse(UUID.randomUUID(), "댓글1", UUID.randomUUID(), reviewId,
+                                "닉네임1", now, now),
+                        new CommentResponse(UUID.randomUUID(), "댓글2", UUID.randomUUID(), reviewId,
+                                "닉네임2", now, now)
+                ),
+                now.toString(),  // nextCursor
+                now,             // nextAfter
+                2,
+                5L,
+                true
+        );
+
+        given(commentQueryService.getComments(any(CommentSearchRequestParam.class)))
+                .willReturn(pageResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/comments")
+                        .param("reviewId", reviewId.toString())
+                        .param("limit", "2")
+                        .param("direction", "DESC"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.hasNext").value(true))
+                .andExpect(jsonPath("$.nextCursor").exists())
+                .andExpect(jsonPath("$.nextAfter").exists())
+                .andExpect(jsonPath("$.totalElements").value(5));
+    }
+
+    @Test
+    @DisplayName("리뷰 ID 누락으로 댓글 목록 조회 실패")
+    void getComments_Fail_400_MissingReviewId() throws Exception {
+        // given - reviewId 없이 요청
+
+        // when & then
+        mockMvc.perform(get("/api/comments"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("잘못된 정렬 방향으로 댓글 목록 조회 실패")
+    void getComments_Fail_400_InvalidDirection() throws Exception {
+        // given
+        UUID reviewId = UUID.randomUUID();
+
+        // when & then
+        mockMvc.perform(get("/api/comments")
+                        .param("reviewId", reviewId.toString())
+                        .param("direction", "INVALID_SORT"))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("잘못된 페이징 파라미터로 댓글 목록 조회 실패")
+    void getComments_Fail_400_InvalidLimit() throws Exception {
+        // given
+        UUID reviewId = UUID.randomUUID();
+
+        // when & then
+        mockMvc.perform(get("/api/comments")
+                        .param("reviewId", reviewId.toString())
+                        // @Min(1) 제약조건 위반 데이터 주입
+                        .param("limit", "0"))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.INVALID_INPUT.name()));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 리뷰 ID로 댓글 목록 조회 실패")
+    void getComments_Fail_404_ReviewNotFound() throws Exception {
+        // given
+        UUID nonExistentReviewId = UUID.randomUUID();
+
+        given(commentQueryService.getComments(any(CommentSearchRequestParam.class)))
+                .willThrow(new BusinessException(ErrorCode.REVIEW_NOT_FOUND, "리뷰를 찾을 수 없습니다."));
+
+        // when & then
+        mockMvc.perform(get("/api/comments")
+                        .param("reviewId", nonExistentReviewId.toString()))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.REVIEW_NOT_FOUND.name()));
+    }
+
+    @Test
+    @DisplayName("서버 내부 오류로 인한 댓글 목록 조회 실패")
+    void getComments_Fail_500_InternalServerError() throws Exception {
+        // given
+        UUID reviewId = UUID.randomUUID();
+
+        given(commentQueryService.getComments(any(CommentSearchRequestParam.class)))
+                .willThrow(new RuntimeException("DB Connection Timeout"));
+
+        // when & then
+        mockMvc.perform(get("/api/comments")
+                        .param("reviewId", reviewId.toString()))
                 .andDo(print())
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.errorCode").value("INTERNAL_SERVER_ERROR"));

--- a/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentQueryServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentQueryServiceTest.java
@@ -1,0 +1,203 @@
+package com.codeit.team4.deokhugam.comment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.codeit.team4.deokhugam.book.entity.Book;
+import com.codeit.team4.deokhugam.book.repository.BookRepository;
+import com.codeit.team4.deokhugam.comment.dto.CommentResponse;
+import com.codeit.team4.deokhugam.comment.dto.CommentSearchRequestParam;
+import com.codeit.team4.deokhugam.comment.entity.Comment;
+import com.codeit.team4.deokhugam.comment.repository.CommentRepository;
+import com.codeit.team4.deokhugam.config.TestContainerConfig;
+import com.codeit.team4.deokhugam.global.error.BusinessException;
+import com.codeit.team4.deokhugam.global.error.ErrorCode;
+import com.codeit.team4.deokhugam.global.response.PageResponse;
+import com.codeit.team4.deokhugam.global.response.SortDirection;
+import com.codeit.team4.deokhugam.review.entity.Review;
+import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
+import com.codeit.team4.deokhugam.user.entity.User;
+import com.codeit.team4.deokhugam.user.repository.UserRepository;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Import(TestContainerConfig.class)
+@ActiveProfiles("test")
+@Transactional
+class CommentQueryServiceTest {
+
+    @Autowired
+    private CommentQueryService commentQueryService;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    private User user;
+    private Review review;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.saveAndFlush(new User("tester@codeit.com", "테스트유저", "password123"));
+        Book book = bookRepository.saveAndFlush(
+                new Book("테스트 도서", "작가", "설명", "출판사", LocalDate.now(), "ISBN-123"));
+        review = reviewRepository.saveAndFlush(new Review(book, user, "리뷰 내용", 5));
+    }
+
+    @Nested
+    @DisplayName("댓글 단건 조회")
+    class GetComment {
+
+        @Test
+        @DisplayName("존재하는 식별자로 댓글 상세 조회 성공")
+        void getComment_Success() {
+            // given
+            Comment savedComment = commentRepository.saveAndFlush(
+                    new Comment(user, review, "상세 조회용 댓글"));
+
+            // when
+            CommentResponse response = commentQueryService.getComment(savedComment.getId());
+
+            // then
+            assertThat(response.id()).isEqualTo(savedComment.getId());
+            assertThat(response.content()).isEqualTo("상세 조회용 댓글");
+            assertThat(response.userNickname()).isEqualTo("테스트유저");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 식별자로 상세 조회 시 실패")
+        void getComment_Fail_NotFound() {
+            // given
+            UUID randomId = UUID.randomUUID();
+
+            // when & then
+            assertThatThrownBy(() -> commentQueryService.getComment(randomId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("논리 삭제된 댓글은 상세 조회 실패")
+        void getComment_Fail_AlreadyDeleted() {
+            // given
+            Comment comment = commentRepository.saveAndFlush(new Comment(user, review, "삭제될 댓글"));
+            comment.softDelete(); // 논리 삭제 처리
+            commentRepository.saveAndFlush(comment);
+
+            // when & then
+            assertThatThrownBy(() -> commentQueryService.getComment(comment.getId()))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("댓글 목록 조회 및 커서 페이지네이션")
+    class GetCommentsPagination {
+
+        @Test
+        @DisplayName("리뷰 ID 기준 첫 페이지 조회 성공")
+        void getComments_FirstPage_Success() {
+            // given: 댓글 3개 생성, 사이즈 2로 조회
+            commentRepository.saveAndFlush(new Comment(user, review, "댓글 1"));
+            commentRepository.saveAndFlush(new Comment(user, review, "댓글 2"));
+            commentRepository.saveAndFlush(new Comment(user, review, "댓글 3"));
+
+            CommentSearchRequestParam param = new CommentSearchRequestParam(
+                    review.getId(), SortDirection.DESC, null, null, 2
+            );
+
+            // when
+            PageResponse<CommentResponse> result = commentQueryService.getComments(param);
+
+            // then
+            assertThat(result.content()).hasSize(2);
+            assertThat(result.hasNext()).isTrue();
+            assertThat(result.nextCursor()).isNotNull();
+            assertThat(result.nextAfter()).isNotNull();
+            assertThat(result.totalElements()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("커서를 이용한 다음 페이지 연계 조회 성공")
+        void getComments_CursorPagination_Success() {
+            // given: 댓글 3개 생성
+            commentRepository.saveAndFlush(new Comment(user, review, "댓글 1"));
+            commentRepository.saveAndFlush(new Comment(user, review, "댓글 2"));
+            commentRepository.saveAndFlush(new Comment(user, review, "댓글 3"));
+
+            // 1페이지 조회 (size 2)
+            CommentSearchRequestParam firstReq = new CommentSearchRequestParam(
+                    review.getId(), SortDirection.DESC, null, null, 2
+            );
+            PageResponse<CommentResponse> firstRes = commentQueryService.getComments(firstReq);
+
+            // when: 1페이지의 커서를 이용해 2페이지 조회
+            CommentSearchRequestParam secondReq = new CommentSearchRequestParam(
+                    review.getId(),
+                    SortDirection.DESC,
+                    firstRes.nextCursor(),
+                    firstRes.nextAfter(),
+                    2
+            );
+            PageResponse<CommentResponse> secondRes = commentQueryService.getComments(secondReq);
+
+            // then
+            assertThat(secondRes.content()).hasSize(1);
+            assertThat(secondRes.content().get(0).content()).isEqualTo("댓글 1");
+            assertThat(secondRes.hasNext()).isFalse();
+            assertThat(secondRes.totalElements()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("오름차순 정렬 및 페이지네이션 성공")
+        void getComments_Ascending_Success() {
+            // given
+            commentRepository.saveAndFlush(new Comment(user, review, "가장 오래된 댓글"));
+            commentRepository.saveAndFlush(new Comment(user, review, "최신 댓글"));
+
+            CommentSearchRequestParam param = new CommentSearchRequestParam(
+                    review.getId(), SortDirection.ASC, null, null, 10
+            );
+
+            // when
+            PageResponse<CommentResponse> result = commentQueryService.getComments(param);
+
+            // then
+            assertThat(result.content().get(0).content()).isEqualTo("가장 오래된 댓글");
+        }
+
+        @Test
+        @DisplayName("커서 파라미터 불일치 시 예외 발생 실패")
+        void getComments_Fail_InvalidCursorParams() {
+            // given
+            CommentSearchRequestParam param = new CommentSearchRequestParam(
+                    review.getId(), SortDirection.DESC, UUID.randomUUID().toString(), null, 10
+            );
+
+            // when & then
+            assertThatThrownBy(() -> commentQueryService.getComments(param))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+        }
+    }
+}

--- a/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentQueryServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentQueryServiceTest.java
@@ -116,6 +116,36 @@ class CommentQueryServiceTest {
     class GetCommentsPagination {
 
         @Test
+        @DisplayName("댓글 논리 삭제 시 목록에서도 제외 성공")
+        void getComments_Success_ExcludeSoftDeleted() {
+            // given
+            Comment comment1 = commentRepository.saveAndFlush(new Comment(user, review, "댓글 1"));
+            Comment comment2 = commentRepository.saveAndFlush(new Comment(user, review, "댓글 2"));
+            Comment comment3 = commentRepository.saveAndFlush(new Comment(user, review, "댓글 3"));
+
+            comment2.softDelete();
+            commentRepository.saveAndFlush(comment2);
+
+            CommentSearchRequestParam param = new CommentSearchRequestParam(
+                    review.getId(), SortDirection.DESC, null, null, 10
+            );
+
+            // when
+            PageResponse<CommentResponse> result = commentQueryService.getComments(param);
+
+            // then
+            assertThat(result.content()).hasSize(2);
+
+            List<UUID> resultIds = result.content().stream()
+                    .map(CommentResponse::id)
+                    .toList();
+
+            assertThat(resultIds)
+                    .contains(comment1.getId(), comment3.getId())
+                    .doesNotContain(comment2.getId());
+        }
+
+        @Test
         @DisplayName("리뷰 ID 기준 첫 페이지 조회 성공")
         void getComments_FirstPage_Success() {
             // given: 댓글 3개 생성, 사이즈 2로 조회
@@ -190,40 +220,6 @@ class CommentQueryServiceTest {
 
             // then
             assertThat(result.content().get(0).content()).isEqualTo("가장 오래된 댓글");
-        }
-
-        @Test
-        @DisplayName("totalElements에서 논리 삭제된 댓글을 제외한 진짜 개수만 반환 성공")
-        void getComments_Success_TotalElementsExcludesSoftDeleted() {
-            // given
-            commentRepository.saveAndFlush(new Comment(user, review, "정상 댓글 1"));
-            reviewRepository.increaseCommentCount(review.getId());
-            commentRepository.saveAndFlush(new Comment(user, review, "정상 댓글 2"));
-            reviewRepository.increaseCommentCount(review.getId());
-
-            Comment deletedComment1 = commentRepository.saveAndFlush(
-                    new Comment(user, review, "삭제 1"));
-            reviewRepository.increaseCommentCount(review.getId());
-            Comment deletedComment2 = commentRepository.saveAndFlush(
-                    new Comment(user, review, "삭제 2"));
-            reviewRepository.increaseCommentCount(review.getId());
-
-            deletedComment1.softDelete();
-            deletedComment2.softDelete();
-            commentRepository.saveAndFlush(deletedComment1);
-            reviewRepository.decreaseCommentCount(review.getId());
-            commentRepository.saveAndFlush(deletedComment2);
-            reviewRepository.decreaseCommentCount(review.getId());
-
-            CommentSearchRequestParam param = new CommentSearchRequestParam(
-                    review.getId(), SortDirection.DESC, null, null, 10
-            );
-
-            // when
-            PageResponse<CommentResponse> result = commentQueryService.getComments(param);
-
-            // then
-            assertThat(result.totalElements()).isEqualTo(2L);
         }
 
         @Test

--- a/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentQueryServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentQueryServiceTest.java
@@ -253,35 +253,5 @@ class CommentQueryServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
         }
-
-        @Test
-        @DisplayName("논리 삭제된 댓글은 목록 조회 실패")
-        void getComments_Fail_SoftDeletedComment() {
-            // given
-            Comment comment1 = commentRepository.saveAndFlush(
-                    new Comment(user, review, "살아있는 댓글 1"));
-            Comment comment2 = commentRepository.saveAndFlush(
-                    new Comment(user, review, "삭제될 댓글 2"));
-            Comment comment3 = commentRepository.saveAndFlush(
-                    new Comment(user, review, "살아있는 댓글 3"));
-
-            comment2.softDelete();
-            commentRepository.saveAndFlush(comment2);
-
-            CommentSearchRequestParam param = new CommentSearchRequestParam(
-                    review.getId(), SortDirection.DESC, null, null, 10
-            );
-
-            // when
-            PageResponse<CommentResponse> result = commentQueryService.getComments(param);
-
-            // then
-            assertThat(result.content()).hasSize(2);
-
-            List<UUID> resultIds = result.content().stream().map(CommentResponse::id).toList();
-            assertThat(resultIds)
-                    .contains(comment1.getId(), comment3.getId())
-                    .doesNotContain(comment2.getId());
-        }
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentQueryServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentQueryServiceTest.java
@@ -20,6 +20,7 @@ import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.repository.UserRepository;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -100,7 +101,7 @@ class CommentQueryServiceTest {
         void getComment_Fail_AlreadyDeleted() {
             // given
             Comment comment = commentRepository.saveAndFlush(new Comment(user, review, "삭제될 댓글"));
-            comment.softDelete(); // 논리 삭제 처리
+            comment.softDelete();
             commentRepository.saveAndFlush(comment);
 
             // when & then
@@ -119,8 +120,11 @@ class CommentQueryServiceTest {
         void getComments_FirstPage_Success() {
             // given: 댓글 3개 생성, 사이즈 2로 조회
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 1"));
+            reviewRepository.increaseCommentCount(review.getId());
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 2"));
+            reviewRepository.increaseCommentCount(review.getId());
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 3"));
+            reviewRepository.increaseCommentCount(review.getId());
 
             CommentSearchRequestParam param = new CommentSearchRequestParam(
                     review.getId(), SortDirection.DESC, null, null, 2
@@ -140,18 +144,20 @@ class CommentQueryServiceTest {
         @Test
         @DisplayName("커서를 이용한 다음 페이지 연계 조회 성공")
         void getComments_CursorPagination_Success() {
-            // given: 댓글 3개 생성
+            // given
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 1"));
+            reviewRepository.increaseCommentCount(review.getId());
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 2"));
+            reviewRepository.increaseCommentCount(review.getId());
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 3"));
+            reviewRepository.increaseCommentCount(review.getId());
 
-            // 1페이지 조회 (size 2)
             CommentSearchRequestParam firstReq = new CommentSearchRequestParam(
                     review.getId(), SortDirection.DESC, null, null, 2
             );
             PageResponse<CommentResponse> firstRes = commentQueryService.getComments(firstReq);
 
-            // when: 1페이지의 커서를 이용해 2페이지 조회
+            // when
             CommentSearchRequestParam secondReq = new CommentSearchRequestParam(
                     review.getId(),
                     SortDirection.DESC,
@@ -187,6 +193,58 @@ class CommentQueryServiceTest {
         }
 
         @Test
+        @DisplayName("totalElements에서 논리 삭제된 댓글을 제외한 진짜 개수만 반환 성공")
+        void getComments_Success_TotalElementsExcludesSoftDeleted() {
+            // given
+            commentRepository.saveAndFlush(new Comment(user, review, "정상 댓글 1"));
+            reviewRepository.increaseCommentCount(review.getId());
+            commentRepository.saveAndFlush(new Comment(user, review, "정상 댓글 2"));
+            reviewRepository.increaseCommentCount(review.getId());
+
+            Comment deletedComment1 = commentRepository.saveAndFlush(
+                    new Comment(user, review, "삭제 1"));
+            reviewRepository.increaseCommentCount(review.getId());
+            Comment deletedComment2 = commentRepository.saveAndFlush(
+                    new Comment(user, review, "삭제 2"));
+            reviewRepository.increaseCommentCount(review.getId());
+
+            deletedComment1.softDelete();
+            deletedComment2.softDelete();
+            commentRepository.saveAndFlush(deletedComment1);
+            reviewRepository.decreaseCommentCount(review.getId());
+            commentRepository.saveAndFlush(deletedComment2);
+            reviewRepository.decreaseCommentCount(review.getId());
+
+            CommentSearchRequestParam param = new CommentSearchRequestParam(
+                    review.getId(), SortDirection.DESC, null, null, 10
+            );
+
+            // when
+            PageResponse<CommentResponse> result = commentQueryService.getComments(param);
+
+            // then
+            assertThat(result.totalElements()).isEqualTo(2L);
+        }
+
+        @Test
+        @DisplayName("cursor와 after가 모두 null일 때 첫 페이지 조회 성공")
+        void getComments_Success_FirstPage_BothCursorParamsNull() {
+            // given: 초기 진입(첫 페이지) 상태
+            commentRepository.saveAndFlush(new Comment(user, review, "댓글 1"));
+
+            CommentSearchRequestParam param = new CommentSearchRequestParam(
+                    review.getId(), SortDirection.DESC, null, null, 10
+            );
+
+            // when
+            PageResponse<CommentResponse> result = commentQueryService.getComments(param);
+
+            // then
+            assertThat(result.content()).hasSize(1);
+            assertThat(result.content().get(0).content()).isEqualTo("댓글 1");
+        }
+
+        @Test
         @DisplayName("커서 파라미터 불일치 시 예외 발생 실패")
         void getComments_Fail_InvalidCursorParams() {
             // given
@@ -198,6 +256,36 @@ class CommentQueryServiceTest {
             assertThatThrownBy(() -> commentQueryService.getComments(param))
                     .isInstanceOf(BusinessException.class)
                     .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+        }
+
+        @Test
+        @DisplayName("논리 삭제된 댓글은 목록 조회 실패")
+        void getComments_Fail_SoftDeletedComment() {
+            // given
+            Comment comment1 = commentRepository.saveAndFlush(
+                    new Comment(user, review, "살아있는 댓글 1"));
+            Comment comment2 = commentRepository.saveAndFlush(
+                    new Comment(user, review, "삭제될 댓글 2"));
+            Comment comment3 = commentRepository.saveAndFlush(
+                    new Comment(user, review, "살아있는 댓글 3"));
+
+            comment2.softDelete();
+            commentRepository.saveAndFlush(comment2);
+
+            CommentSearchRequestParam param = new CommentSearchRequestParam(
+                    review.getId(), SortDirection.DESC, null, null, 10
+            );
+
+            // when
+            PageResponse<CommentResponse> result = commentQueryService.getComments(param);
+
+            // then
+            assertThat(result.content()).hasSize(2);
+
+            List<UUID> resultIds = result.content().stream().map(CommentResponse::id).toList();
+            assertThat(resultIds)
+                    .contains(comment1.getId(), comment3.getId())
+                    .doesNotContain(comment2.getId());
         }
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/repository/ReviewRepositoryTest.java
@@ -236,6 +236,17 @@ class ReviewRepositoryTest {
 
             assertThat(updatedReview.getCommentCount()).isEqualTo(1);
         }
+
+        @Test
+        @DisplayName("댓글 수 0 이하로 감소하지 않음 성공")
+        void decreaseCommentCount_notBelowZero_success() {
+            Review review = reviewRepository.saveAndFlush(new Review(book, user, "content", 5));
+            reviewRepository.decreaseCommentCount(review.getId());
+            entityManager.clear();
+
+            Review found = reviewRepository.findById(review.getId()).get();
+            assertThat(found.getCommentCount()).isEqualTo(0);
+        }
     }
 
     @Nested

--- a/src/test/java/com/codeit/team4/deokhugam/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/repository/ReviewRepositoryTest.java
@@ -217,6 +217,28 @@ class ReviewRepositoryTest {
     }
 
     @Nested
+    @DisplayName("댓글 수 감소")
+    class DecreaseCommentCount {
+        @Test
+        @DisplayName("댓글 수 감소 성공")
+        void decreaseCommentCount_Decreases_ActualDBValue() {
+            // given
+            Review review = reviewRepository.saveAndFlush(new Review(book, user, "리뷰 내용", 5));
+            reviewRepository.increaseCommentCount(review.getId());
+            reviewRepository.increaseCommentCount(review.getId());
+
+            // when
+            reviewRepository.decreaseCommentCount(review.getId());
+
+            // then
+            entityManager.clear();
+            Review updatedReview = reviewRepository.findById(review.getId()).get();
+
+            assertThat(updatedReview.getCommentCount()).isEqualTo(1);
+        }
+    }
+
+    @Nested
     @DisplayName("리뷰 물리 삭제 시 연관 객체 CASCADE 삭제")
     class HardDeleteCascade {
         @Test


### PR DESCRIPTION
## 관련 이슈
- closes #123 

## 작업 내용
- 특정 리뷰에 대한 댓글 목록을 조회하는 기능 구현
- 특정 댓글 단건 조회 기능 구현

## 변경 사항
- GET /api/comments 댓글 목록 조회 (리뷰 정보는 @ParameterObject로 받아옴)
- GET /api/comments/{commentId} 댓글 단건 조회
- CommentSearchRequestParam: 커서 페이징을 위한 DTO record 추가
- CommentQueryService: jOOQ 기반 댓글 조회 전용 서비스 추가
- CommentModel: jOOQ 쿼리 결과 매핑 모델
- CommentResponse: 조회 공통 응답 DTO
- CommentMapper: 엔티티 및 모델을 CommentResponse로 변환하는 매퍼
- 쿼리 서비스 테스트(Testcontainers)와 컨트롤러 단위 테스트 작성

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 개별 댓글 조회(GET) 추가
  * 댓글 목록 조회(GET) 추가 — 리뷰별 필터, 정렬, 커서 기반 페이징과 기본/최대 제한 지원
  * 목록 응답에 다음 페이지 유무, 다음 커서·타임스탬프 및 전체 요소 수 포함

* **테스트**
  * 컨트롤러 및 조회 서비스의 단위/통합 테스트 추가(성공, 유효성 검사, 미존재 및 오류 케이스 포함)
  * 리뷰 댓글 수 감소 동작에 대한 저장소 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->