### PR TITLE
fix: 회원가입 내부 예외 정보 응답 노출 방지

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
@@ -51,10 +51,18 @@ public class UserService {
             log.info("회원가입 성공: userId={}", savedUser.getId());
 
             return userMapper.toResponse(savedUser);
+
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(
                     ErrorCode.DUPLICATE_EMAIL,
-                    "email=" + request.email());
+                    "이미 사용 중인 이메일입니다."
+            );
+
+        } catch (Exception e) {
+            throw new BusinessException(
+                    ErrorCode.INTERNAL_SERVER_ERROR,
+                    "회원가입 처리 중 오류가 발생했습니다."
+            );
         }
     }
 

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
@@ -56,7 +56,8 @@ public class UserService {
             throw new BusinessException(
                     ErrorCode.DUPLICATE_EMAIL, "email=" + request.email()
             );
-
+        } catch (BusinessException e) {
+            throw e;
         } catch (Exception e) {
             log.error("회원가입 처리 중 예상치 못한 예외 발생: email={}", request.email(), e);
             throw new BusinessException(

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
@@ -54,14 +54,13 @@ public class UserService {
 
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(
-                    ErrorCode.DUPLICATE_EMAIL,
-                    "이미 사용 중인 이메일입니다."
+                    ErrorCode.DUPLICATE_EMAIL, "email=" + request.email()
             );
 
         } catch (Exception e) {
+            log.error("회원가입 처리 중 예상치 못한 예외 발생: email={}", request.email(), e);
             throw new BusinessException(
-                    ErrorCode.INTERNAL_SERVER_ERROR,
-                    "회원가입 처리 중 오류가 발생했습니다."
+                    ErrorCode.INTERNAL_SERVER_ERROR, "email=" + request.email()
             );
         }
     }

--- a/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
@@ -126,6 +126,31 @@ class UserServiceImplTest {
     }
 
     @Test
+    @DisplayName("회원가입 중 예상치 못한 예외 발생")
+    void registerUser_fail_internalServerError() {
+        // given
+        UserRegisterRequest request = new UserRegisterRequest(
+                "test@test.com",
+                "user1",
+                "password1!"
+        );
+
+        when(userRepository.existsByEmailAndDeletedAtIsNull(request.email()))
+                .thenReturn(false);
+
+        when(userRepository.save(any(User.class)))
+                .thenThrow(new RuntimeException("DB crash"));
+
+        // when & then
+        assertThatThrownBy(() -> userService.registerUser(request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
     @DisplayName("로그인 성공")
     void loginUser_success() {
         // given

--- a/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceImplTest.java
@@ -126,7 +126,7 @@ class UserServiceImplTest {
     }
 
     @Test
-    @DisplayName("회원가입 중 예상치 못한 예외 발생")
+    @DisplayName("예상치 못한 예외 발생으로 회원가입 실패")
     void registerUser_fail_internalServerError() {
         // given
         UserRegisterRequest request = new UserRegisterRequest(


### PR DESCRIPTION
## 관련 이슈
- closes #220 

## 작업 내용
- 회원가입 처리 과정에서 발생 가능한 예외를 통제된 응답으로 변환하도록 개선

## 변경 사항
- 회원가입 처리 과정에서 발생한 500 에러 응답에 Hibernate SQL 및 DB 관련 내부 정보가 노출될 수 있는 문제 발생
- 서비스 레이어에서 발생하는 예외를 BusinessException으로 변환하여 도메인 단위의 예외로 변경
- 관련 테스트 코드 작성

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **버그 수정**
  * 사용자 등록 실패 시 오류 메시지가 더 명확한 한국어로 제공됩니다
  * 예상치 못한 오류 발생 시 적절한 예외 처리를 통해 안정성이 향상되었습니다

* **테스트**
  * 사용자 등록 프로세스의 오류 처리 케이스에 대한 테스트가 추가되었습니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->