### PR TITLE
feat: 리뷰 이벤트 기반 도서 집계(BookStatistics) 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.redisson:redisson-spring-boot-starter:3.50.0'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework:spring-aspects'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/codeit/team4/deokhugam/book/entity/BookStatistics.java
+++ b/src/main/java/com/codeit/team4/deokhugam/book/entity/BookStatistics.java
@@ -1,0 +1,63 @@
+package com.codeit.team4.deokhugam.book.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "book_statistics")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BookStatistics {
+
+    @Id
+    @Column(name = "book_id")
+    private UUID bookId;
+
+    @Column(nullable = false)
+    private int ratingSum;
+
+    @Column(nullable = false)
+    private int reviewCount;
+
+    public BookStatistics(UUID bookId) {
+        this.bookId = bookId;
+        this.ratingSum = 0;
+        this.reviewCount = 0;
+    }
+
+    public void onReviewCreated(int rating) {
+        this.reviewCount++;
+        this.ratingSum += rating;
+    }
+
+    public void onReviewDeleted(int rating) {
+        if (this.reviewCount > 0) {
+            this.reviewCount--;
+            this.ratingSum -= rating;
+        }
+    }
+
+    public void onReviewUpdated(
+            int oldRating,
+            int newRating
+    ) {
+        this.ratingSum += (newRating - oldRating);
+    }
+
+    public BigDecimal getAverageRating() {
+        if (reviewCount == 0) {
+            return BigDecimal.ZERO;
+        }
+        //소수점 2자리까지 반올림
+        return BigDecimal.valueOf(ratingSum)
+                .divide(BigDecimal.valueOf(reviewCount), 2, RoundingMode.HALF_UP);
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/book/entity/BookStatistics.java
+++ b/src/main/java/com/codeit/team4/deokhugam/book/entity/BookStatistics.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -39,10 +40,11 @@ public class BookStatistics {
     }
 
     public void onReviewDeleted(int rating) {
-        if (this.reviewCount > 0) {
-            this.reviewCount--;
-            this.ratingSum -= rating;
+        if (this.reviewCount <= 0) {
+            return;
         }
+        this.reviewCount--;
+        this.ratingSum = Math.max(0, this.ratingSum - rating);
     }
 
     public void onReviewUpdated(
@@ -50,6 +52,22 @@ public class BookStatistics {
             int newRating
     ) {
         this.ratingSum += (newRating - oldRating);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BookStatistics other)) {
+            return false;
+        }
+        return Objects.equals(bookId, other.bookId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(bookId);
     }
 
     public BigDecimal getAverageRating() {

--- a/src/main/java/com/codeit/team4/deokhugam/book/listener/BookStatisticsEventListener.java
+++ b/src/main/java/com/codeit/team4/deokhugam/book/listener/BookStatisticsEventListener.java
@@ -6,8 +6,11 @@ import com.codeit.team4.deokhugam.global.lock.DistributedLock;
 import com.codeit.team4.deokhugam.review.event.ReviewCreatedEvent;
 import com.codeit.team4.deokhugam.review.event.ReviewDeletedEvent;
 import com.codeit.team4.deokhugam.review.event.ReviewUpdatedEvent;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
@@ -26,39 +29,66 @@ public class BookStatisticsEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @DistributedLock(key = "deokhugam:book-statistics", lockParam = {"event.bookId"})
-    @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 500))
+    @Retryable(
+            retryFor = PessimisticLockingFailureException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 500)
+    )
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleReviewCreated(ReviewCreatedEvent event) {
         log.debug("ReviewCreatedEvent 수신: {}", event);
 
         BookStatistics statistics = bookStatisticsRepository.findById(event.bookId())
-                .orElseGet(() -> bookStatisticsRepository.save(
-                        new BookStatistics(event.bookId())));
-
+                .orElseGet(() -> new BookStatistics(event.bookId()));
         statistics.onReviewCreated(event.rating());
+        bookStatisticsRepository.save(statistics);
+
+        log.info("BookStatistics 갱신 완료 (ReviewCreated): bookId={}, count={}, sum={}",
+                event.bookId(), statistics.getReviewCount(), statistics.getRatingSum());
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @DistributedLock(key = "deokhugam:book-statistics", lockParam = {"event.bookId"})
-    @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 500))
+    @Retryable(
+            retryFor = PessimisticLockingFailureException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 500)
+    )
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleReviewUpdated(ReviewUpdatedEvent event) {
         log.debug("ReviewUpdatedEvent 수신: {}", event);
 
-        bookStatisticsRepository.findById(event.bookId())
-                .ifPresent(statistics ->
-                        statistics.onReviewUpdated(event.oldRating(), event.newRating()));
+        findStatistics(event.bookId(), "업데이트").ifPresent(statistics -> {
+            statistics.onReviewUpdated(event.oldRating(), event.newRating());
+            log.info("BookStatistics 갱신 완료 (ReviewUpdated): bookId={}, count={}, sum={}",
+                    event.bookId(), statistics.getReviewCount(), statistics.getRatingSum());
+        });
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @DistributedLock(key = "deokhugam:book-statistics", lockParam = {"event.bookId"})
-    @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 500))
+    @Retryable(
+            retryFor = PessimisticLockingFailureException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 500)
+    )
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleReviewDeleted(ReviewDeletedEvent event) {
         log.debug("ReviewDeletedEvent 수신: {}", event);
 
-        bookStatisticsRepository.findById(event.bookId())
-                .ifPresent(statistics -> statistics.onReviewDeleted(event.rating()));
+        findStatistics(event.bookId(), "삭제").ifPresent(statistics -> {
+            statistics.onReviewDeleted(event.rating());
+            log.info("BookStatistics 갱신 완료 (ReviewDeleted): bookId={}, count={}, sum={}",
+                    event.bookId(), statistics.getReviewCount(), statistics.getRatingSum());
+        });
+    }
+
+    private Optional<BookStatistics> findStatistics(UUID bookId, String eventType) {
+        Optional<BookStatistics> statistics = bookStatisticsRepository.findById(bookId);
+        if (statistics.isEmpty()) {
+            log.warn("BookStatistics 미존재로 {} 누락: bookId={}", eventType, bookId);
+        }
+        return statistics;
     }
 
     @Recover

--- a/src/main/java/com/codeit/team4/deokhugam/book/listener/BookStatisticsEventListener.java
+++ b/src/main/java/com/codeit/team4/deokhugam/book/listener/BookStatisticsEventListener.java
@@ -1,0 +1,81 @@
+package com.codeit.team4.deokhugam.book.listener;
+
+import com.codeit.team4.deokhugam.book.entity.BookStatistics;
+import com.codeit.team4.deokhugam.book.repository.BookStatisticsRepository;
+import com.codeit.team4.deokhugam.global.lock.DistributedLock;
+import com.codeit.team4.deokhugam.review.event.ReviewCreatedEvent;
+import com.codeit.team4.deokhugam.review.event.ReviewDeletedEvent;
+import com.codeit.team4.deokhugam.review.event.ReviewUpdatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BookStatisticsEventListener {
+
+    private final BookStatisticsRepository bookStatisticsRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @DistributedLock(key = "deokhugam:book-statistics", lockParam = {"event.bookId"})
+    @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 500))
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleReviewCreated(ReviewCreatedEvent event) {
+        log.debug("ReviewCreatedEvent 수신: {}", event);
+
+        BookStatistics statistics = bookStatisticsRepository.findById(event.bookId())
+                .orElseGet(() -> bookStatisticsRepository.save(
+                        new BookStatistics(event.bookId())));
+
+        statistics.onReviewCreated(event.rating());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @DistributedLock(key = "deokhugam:book-statistics", lockParam = {"event.bookId"})
+    @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 500))
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleReviewUpdated(ReviewUpdatedEvent event) {
+        log.debug("ReviewUpdatedEvent 수신: {}", event);
+
+        bookStatisticsRepository.findById(event.bookId())
+                .ifPresent(statistics ->
+                        statistics.onReviewUpdated(event.oldRating(), event.newRating()));
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @DistributedLock(key = "deokhugam:book-statistics", lockParam = {"event.bookId"})
+    @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 500))
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleReviewDeleted(ReviewDeletedEvent event) {
+        log.debug("ReviewDeletedEvent 수신: {}", event);
+
+        bookStatisticsRepository.findById(event.bookId())
+                .ifPresent(statistics -> statistics.onReviewDeleted(event.rating()));
+    }
+
+    @Recover
+    public void recover(Exception e, ReviewCreatedEvent event) {
+        log.error("BookStatistics 갱신 최종 실패 (ReviewCreated): bookId={}, rating={}",
+                event.bookId(), event.rating(), e);
+    }
+
+    @Recover
+    public void recover(Exception e, ReviewUpdatedEvent event) {
+        log.error("BookStatistics 갱신 최종 실패 (ReviewUpdated): bookId={}, oldRating={}, newRating={}",
+                event.bookId(), event.oldRating(), event.newRating(), e);
+    }
+
+    @Recover
+    public void recover(Exception e, ReviewDeletedEvent event) {
+        log.error("BookStatistics 갱신 최종 실패 (ReviewDeleted): bookId={}, rating={}",
+                event.bookId(), event.rating(), e);
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/book/repository/BookStatisticsRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/book/repository/BookStatisticsRepository.java
@@ -1,0 +1,9 @@
+package com.codeit.team4.deokhugam.book.repository;
+
+import com.codeit.team4.deokhugam.book.entity.BookStatistics;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookStatisticsRepository extends JpaRepository<BookStatistics, UUID> {
+
+}

--- a/src/main/java/com/codeit/team4/deokhugam/global/config/RetryConfig.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/config/RetryConfig.java
@@ -1,0 +1,10 @@
+package com.codeit.team4.deokhugam.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+
+}

--- a/src/main/java/com/codeit/team4/deokhugam/review/event/ReviewCreatedEvent.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/event/ReviewCreatedEvent.java
@@ -1,0 +1,10 @@
+package com.codeit.team4.deokhugam.review.event;
+
+import java.util.UUID;
+
+public record ReviewCreatedEvent(
+        UUID bookId,
+        int rating
+) {
+
+}

--- a/src/main/java/com/codeit/team4/deokhugam/review/event/ReviewDeletedEvent.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/event/ReviewDeletedEvent.java
@@ -1,0 +1,10 @@
+package com.codeit.team4.deokhugam.review.event;
+
+import java.util.UUID;
+
+public record ReviewDeletedEvent(
+        UUID bookId,
+        int rating
+) {
+
+}

--- a/src/main/java/com/codeit/team4/deokhugam/review/event/ReviewUpdatedEvent.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/event/ReviewUpdatedEvent.java
@@ -1,0 +1,11 @@
+package com.codeit.team4.deokhugam.review.event;
+
+import java.util.UUID;
+
+public record ReviewUpdatedEvent(
+        UUID bookId,
+        int oldRating,
+        int newRating
+) {
+
+}

--- a/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
@@ -1,12 +1,14 @@
 package com.codeit.team4.deokhugam.review.service;
 
 import com.codeit.team4.deokhugam.book.entity.Book;
-import com.codeit.team4.deokhugam.book.repository.BookRepository;
 import com.codeit.team4.deokhugam.book.service.BookService;
 import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.global.error.ErrorCode;
 import com.codeit.team4.deokhugam.global.lock.DistributedLock;
 import com.codeit.team4.deokhugam.notification.event.LikeEvent;
+import com.codeit.team4.deokhugam.review.event.ReviewCreatedEvent;
+import com.codeit.team4.deokhugam.review.event.ReviewDeletedEvent;
+import com.codeit.team4.deokhugam.review.event.ReviewUpdatedEvent;
 import com.codeit.team4.deokhugam.review.dto.ReviewCreateRequest;
 import com.codeit.team4.deokhugam.review.dto.ReviewLikeResponse;
 import com.codeit.team4.deokhugam.review.dto.ReviewResponse;
@@ -36,7 +38,6 @@ public class ReviewService {
     private final ReviewLikeRepository reviewLikeRepository;
     private final UserService userService;
     private final BookService bookService;
-    private final BookRepository bookRepository;
     private final ReviewMapper reviewMapper;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -56,7 +57,7 @@ public class ReviewService {
         Review review = new Review(book, user, request.content(), request.rating());
 
         reviewRepository.save(review);
-        bookRepository.increaseReviewCount(book.getId());
+        eventPublisher.publishEvent(new ReviewCreatedEvent(book.getId(), request.rating()));
         log.info("리뷰 생성 완료: reviewId={}", review.getId());
 
         return reviewMapper.toResponse(review, false);
@@ -72,12 +73,6 @@ public class ReviewService {
         return reviewRepository.findAllById(reviewIds);
     }
 
-    public Review findWithDeletedById(UUID reviewId) {
-        return reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new BusinessException(
-                        ErrorCode.REVIEW_NOT_FOUND, "reviewId=" + reviewId));
-    }
-
     @Transactional
     @DistributedLock(key = "deokhugam:review", lockParam = {"reviewId"})
     public ReviewResponse updateReview(UUID reviewId, UUID userId, ReviewUpdateRequest request) {
@@ -85,7 +80,13 @@ public class ReviewService {
 
         validateReviewOwner(review, userId);
 
+        int oldRating = review.getRating();
         review.update(request.content(), request.rating());
+
+        if (oldRating != request.rating()) {
+            eventPublisher.publishEvent(
+                    new ReviewUpdatedEvent(review.getBook().getId(), oldRating, request.rating()));
+        }
         log.info("리뷰 수정 완료: reviewId={}", review.getId());
 
         return reviewMapper.toResponse(review, isLikedByUser(reviewId, userId));
@@ -98,7 +99,8 @@ public class ReviewService {
 
         validateReviewOwner(review, userId);
         review.softDelete();
-        bookRepository.decreaseReviewCount(review.getBook().getId());
+        eventPublisher.publishEvent(
+                new ReviewDeletedEvent(review.getBook().getId(), review.getRating()));
         log.info("리뷰 논리 삭제 완료: reviewId={}", review.getId());
     }
 
@@ -109,7 +111,8 @@ public class ReviewService {
 
         validateReviewOwner(review, userId);
         if (review.getDeletedAt() == null) {
-            bookRepository.decreaseReviewCount(review.getBook().getId());
+            eventPublisher.publishEvent(
+                    new ReviewDeletedEvent(review.getBook().getId(), review.getRating()));
         }
 
         reviewRepository.delete(review);
@@ -171,7 +174,13 @@ public class ReviewService {
         return reviewLikeRepository.existsByReviewIdAndUserId(reviewId, userId);
     }
 
-    private static void validateReviewOwner(Review review, UUID userId) {
+    private Review findWithDeletedById(UUID reviewId) {
+        return reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new BusinessException(
+                        ErrorCode.REVIEW_NOT_FOUND, "reviewId=" + reviewId));
+    }
+
+    private void validateReviewOwner(Review review, UUID userId) {
         if (!review.isOwner(userId)) {
             throw new BusinessException(
                     ErrorCode.REVIEW_NOT_OWNER, "reviewId=" + review.getId() + ", userId=" + userId);

--- a/src/main/resources/db/migration/V3__add_book_statistics.sql
+++ b/src/main/resources/db/migration/V3__add_book_statistics.sql
@@ -1,0 +1,6 @@
+-- book_statistics (도서 집계)
+CREATE TABLE book_statistics (
+    book_id       UUID PRIMARY KEY REFERENCES books(id) ON DELETE CASCADE,
+    rating_sum    INT NOT NULL DEFAULT 0,
+    review_count  INT NOT NULL DEFAULT 0
+);

--- a/src/test/java/com/codeit/team4/deokhugam/book/entity/BookStatisticsTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/book/entity/BookStatisticsTest.java
@@ -1,0 +1,134 @@
+package com.codeit.team4.deokhugam.book.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class BookStatisticsTest {
+
+    @Nested
+    @DisplayName("onReviewCreated")
+    class OnReviewCreated {
+
+        @Test
+        @DisplayName("리뷰 생성 시 reviewCount 증가 및 ratingSum 반영 성공")
+        void onReviewCreated_success() {
+            BookStatistics statistics = new BookStatistics(UUID.randomUUID());
+
+            statistics.onReviewCreated(4);
+
+            assertThat(statistics.getReviewCount()).isEqualTo(1);
+            assertThat(statistics.getRatingSum()).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("리뷰 여러 건 생성 시 누적 성공")
+        void onReviewCreated_multiple_success() {
+            BookStatistics statistics = new BookStatistics(UUID.randomUUID());
+
+            statistics.onReviewCreated(5);
+            statistics.onReviewCreated(3);
+            statistics.onReviewCreated(4);
+
+            assertThat(statistics.getReviewCount()).isEqualTo(3);
+            assertThat(statistics.getRatingSum()).isEqualTo(12);
+        }
+    }
+
+    @Nested
+    @DisplayName("onReviewDeleted")
+    class OnReviewDeleted {
+
+        @Test
+        @DisplayName("리뷰 삭제 시 reviewCount 감소 및 ratingSum 반영 성공")
+        void onReviewDeleted_success() {
+            BookStatistics statistics = new BookStatistics(UUID.randomUUID());
+            statistics.onReviewCreated(5);
+            statistics.onReviewCreated(3);
+
+            statistics.onReviewDeleted(5);
+
+            assertThat(statistics.getReviewCount()).isEqualTo(1);
+            assertThat(statistics.getRatingSum()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("reviewCount가 0일 때 삭제해도 음수가 되지 않음")
+        void onReviewDeleted_zeroCount_success() {
+            BookStatistics statistics = new BookStatistics(UUID.randomUUID());
+
+            statistics.onReviewDeleted(5);
+
+            assertThat(statistics.getReviewCount()).isEqualTo(0);
+            assertThat(statistics.getRatingSum()).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("onReviewUpdated")
+    class OnReviewUpdated {
+
+        @Test
+        @DisplayName("리뷰 수정 시 ratingSum 변경 성공")
+        void onReviewUpdated_success() {
+            BookStatistics statistics = new BookStatistics(UUID.randomUUID());
+            statistics.onReviewCreated(3);
+
+            statistics.onReviewUpdated(3, 5);
+
+            assertThat(statistics.getReviewCount()).isEqualTo(1);
+            assertThat(statistics.getRatingSum()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("같은 별점으로 수정 시 ratingSum 변경 없음")
+        void onReviewUpdated_sameRating_success() {
+            BookStatistics statistics = new BookStatistics(UUID.randomUUID());
+            statistics.onReviewCreated(4);
+
+            statistics.onReviewUpdated(4, 4);
+
+            assertThat(statistics.getRatingSum()).isEqualTo(4);
+        }
+    }
+
+    @Nested
+    @DisplayName("getAverageRating")
+    class GetAverageRating {
+
+        @Test
+        @DisplayName("리뷰가 없을 때 평균 0 반환 성공")
+        void getAverageRating_noReviews_success() {
+            BookStatistics statistics = new BookStatistics(UUID.randomUUID());
+
+            assertThat(statistics.getAverageRating()).isEqualByComparingTo(BigDecimal.ZERO);
+        }
+
+        @Test
+        @DisplayName("평균 별점 소수점 2자리 반올림 성공")
+        void getAverageRating_roundHalfUp_success() {
+            BookStatistics statistics = new BookStatistics(UUID.randomUUID());
+            statistics.onReviewCreated(4);
+            statistics.onReviewCreated(3);
+            statistics.onReviewCreated(4);
+
+            // (4 + 3 + 4) / 3 = 3.666... → 3.67
+            assertThat(statistics.getAverageRating()).isEqualByComparingTo(new BigDecimal("3.67"));
+        }
+
+        @Test
+        @DisplayName("나누어떨어지는 평균 별점 계산 성공")
+        void getAverageRating_exact_success() {
+            BookStatistics statistics = new BookStatistics(UUID.randomUUID());
+            statistics.onReviewCreated(4);
+            statistics.onReviewCreated(4);
+
+            // (4 + 4) / 2 = 4.00
+            assertThat(statistics.getAverageRating()).isEqualByComparingTo(new BigDecimal("4.00"));
+        }
+    }
+}

--- a/src/test/java/com/codeit/team4/deokhugam/book/listener/BookStatisticsEventListenerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/book/listener/BookStatisticsEventListenerTest.java
@@ -1,0 +1,194 @@
+package com.codeit.team4.deokhugam.book.listener;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.codeit.team4.deokhugam.book.entity.BookStatistics;
+import com.codeit.team4.deokhugam.book.repository.BookStatisticsRepository;
+import com.codeit.team4.deokhugam.review.event.ReviewCreatedEvent;
+import com.codeit.team4.deokhugam.review.event.ReviewDeletedEvent;
+import com.codeit.team4.deokhugam.review.event.ReviewUpdatedEvent;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BookStatisticsEventListenerTest {
+
+    @InjectMocks
+    private BookStatisticsEventListener listener;
+
+    @Mock
+    private BookStatisticsRepository bookStatisticsRepository;
+
+    @Nested
+    @DisplayName("handleReviewCreated")
+    class HandleReviewCreated {
+
+        @Test
+        @DisplayName("기존 통계가 있을 때 리뷰 생성 이벤트 처리 성공")
+        void handleReviewCreated_existingStatistics_success() {
+            UUID bookId = UUID.randomUUID();
+            BookStatistics statistics = new BookStatistics(bookId);
+            ReviewCreatedEvent event = new ReviewCreatedEvent(bookId, 5);
+
+            given(bookStatisticsRepository.findById(bookId))
+                    .willReturn(Optional.of(statistics));
+
+            listener.handleReviewCreated(event);
+
+            verify(bookStatisticsRepository).findById(bookId);
+            verify(bookStatisticsRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("통계가 없을 때 새로 생성 후 리뷰 생성 이벤트 처리 성공")
+        void handleReviewCreated_newStatistics_success() {
+            UUID bookId = UUID.randomUUID();
+            BookStatistics statistics = new BookStatistics(bookId);
+            ReviewCreatedEvent event = new ReviewCreatedEvent(bookId, 4);
+
+            given(bookStatisticsRepository.findById(bookId))
+                    .willReturn(Optional.empty());
+            given(bookStatisticsRepository.save(any(BookStatistics.class)))
+                    .willReturn(statistics);
+
+            listener.handleReviewCreated(event);
+
+            verify(bookStatisticsRepository).save(any(BookStatistics.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("handleReviewUpdated")
+    class HandleReviewUpdated {
+
+        @Test
+        @DisplayName("리뷰 수정 이벤트 처리 성공")
+        void handleReviewUpdated_success() {
+            UUID bookId = UUID.randomUUID();
+            BookStatistics statistics = new BookStatistics(bookId);
+            statistics.onReviewCreated(3);
+            ReviewUpdatedEvent event = new ReviewUpdatedEvent(bookId, 3, 5);
+
+            given(bookStatisticsRepository.findById(bookId))
+                    .willReturn(Optional.of(statistics));
+
+            listener.handleReviewUpdated(event);
+
+            verify(bookStatisticsRepository).findById(bookId);
+        }
+
+        @Test
+        @DisplayName("통계가 없을 때 리뷰 수정 이벤트 무시 성공")
+        void handleReviewUpdated_noStatistics_success() {
+            UUID bookId = UUID.randomUUID();
+            ReviewUpdatedEvent event = new ReviewUpdatedEvent(bookId, 3, 5);
+
+            given(bookStatisticsRepository.findById(bookId))
+                    .willReturn(Optional.empty());
+
+            listener.handleReviewUpdated(event);
+
+            verify(bookStatisticsRepository).findById(bookId);
+        }
+    }
+
+    @Nested
+    @DisplayName("handleReviewDeleted")
+    class HandleReviewDeleted {
+
+        @Test
+        @DisplayName("리뷰 삭제 이벤트 처리 성공")
+        void handleReviewDeleted_success() {
+            UUID bookId = UUID.randomUUID();
+            BookStatistics statistics = new BookStatistics(bookId);
+            statistics.onReviewCreated(4);
+            ReviewDeletedEvent event = new ReviewDeletedEvent(bookId, 4);
+
+            given(bookStatisticsRepository.findById(bookId))
+                    .willReturn(Optional.of(statistics));
+
+            listener.handleReviewDeleted(event);
+
+            verify(bookStatisticsRepository).findById(bookId);
+        }
+
+        @Test
+        @DisplayName("통계가 없을 때 리뷰 삭제 이벤트 무시 성공")
+        void handleReviewDeleted_noStatistics_success() {
+            UUID bookId = UUID.randomUUID();
+            ReviewDeletedEvent event = new ReviewDeletedEvent(bookId, 4);
+
+            given(bookStatisticsRepository.findById(bookId))
+                    .willReturn(Optional.empty());
+
+            listener.handleReviewDeleted(event);
+
+            verify(bookStatisticsRepository).findById(bookId);
+        }
+    }
+
+    @Nested
+    @DisplayName("handleReviewCreated 예외 발생")
+    class HandleReviewCreatedException {
+
+        @Test
+        @DisplayName("repository 예외 시 예외 전파 성공")
+        void handleReviewCreated_exception_success() {
+            UUID bookId = UUID.randomUUID();
+            ReviewCreatedEvent event = new ReviewCreatedEvent(bookId, 5);
+
+            given(bookStatisticsRepository.findById(bookId))
+                    .willThrow(new RuntimeException("DB 연결 실패"));
+
+            assertThatCode(() -> listener.handleReviewCreated(event))
+                    .isInstanceOf(RuntimeException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("recover")
+    class Recover {
+
+        @Test
+        @DisplayName("ReviewCreatedEvent recover 시 예외 전파 없이 종료 성공")
+        void recover_reviewCreated_success() {
+            UUID bookId = UUID.randomUUID();
+            ReviewCreatedEvent event = new ReviewCreatedEvent(bookId, 5);
+
+            assertThatCode(() -> listener.recover(new RuntimeException("실패"), event))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("ReviewUpdatedEvent recover 시 예외 전파 없이 종료 성공")
+        void recover_reviewUpdated_success() {
+            UUID bookId = UUID.randomUUID();
+            ReviewUpdatedEvent event = new ReviewUpdatedEvent(bookId, 3, 5);
+
+            assertThatCode(() -> listener.recover(new RuntimeException("실패"), event))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("ReviewDeletedEvent recover 시 예외 전파 없이 종료 성공")
+        void recover_reviewDeleted_success() {
+            UUID bookId = UUID.randomUUID();
+            ReviewDeletedEvent event = new ReviewDeletedEvent(bookId, 4);
+
+            assertThatCode(() -> listener.recover(new RuntimeException("실패"), event))
+                    .doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/com/codeit/team4/deokhugam/book/listener/BookStatisticsEventListenerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/book/listener/BookStatisticsEventListenerTest.java
@@ -1,5 +1,6 @@
 package com.codeit.team4.deokhugam.book.listener;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -48,7 +49,9 @@ class BookStatisticsEventListenerTest {
             listener.handleReviewCreated(event);
 
             verify(bookStatisticsRepository).findById(bookId);
-            verify(bookStatisticsRepository, never()).save(any());
+            verify(bookStatisticsRepository).save(statistics);
+            assertThat(statistics.getReviewCount()).isEqualTo(1);
+            assertThat(statistics.getRatingSum()).isEqualTo(5);
         }
 
         @Test
@@ -87,6 +90,8 @@ class BookStatisticsEventListenerTest {
             listener.handleReviewUpdated(event);
 
             verify(bookStatisticsRepository).findById(bookId);
+            assertThat(statistics.getReviewCount()).isEqualTo(1);
+            assertThat(statistics.getRatingSum()).isEqualTo(5);
         }
 
         @Test
@@ -122,6 +127,8 @@ class BookStatisticsEventListenerTest {
             listener.handleReviewDeleted(event);
 
             verify(bookStatisticsRepository).findById(bookId);
+            assertThat(statistics.getReviewCount()).isEqualTo(0);
+            assertThat(statistics.getRatingSum()).isEqualTo(0);
         }
 
         @Test

--- a/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewServiceTest.java
@@ -10,10 +10,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.codeit.team4.deokhugam.book.entity.Book;
-import com.codeit.team4.deokhugam.book.repository.BookRepository;
 import com.codeit.team4.deokhugam.book.service.BookService;
 import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.global.error.ErrorCode;
+import com.codeit.team4.deokhugam.review.event.ReviewCreatedEvent;
+import com.codeit.team4.deokhugam.review.event.ReviewDeletedEvent;
 import com.codeit.team4.deokhugam.review.dto.ReviewCreateRequest;
 import com.codeit.team4.deokhugam.review.dto.ReviewLikeResponse;
 import com.codeit.team4.deokhugam.review.dto.ReviewResponse;
@@ -53,9 +54,6 @@ class ReviewServiceTest {
 
     @Mock
     private BookService bookService;
-
-    @Mock
-    private BookRepository bookRepository;
 
     @Mock
     private ReviewMapper reviewMapper;
@@ -104,7 +102,7 @@ class ReviewServiceTest {
             assertThat(response.content()).isEqualTo("좋은 책입니다");
             assertThat(response.rating()).isEqualTo(5);
             verify(reviewRepository).save(any(Review.class));
-            verify(bookRepository).increaseReviewCount(bookId);
+            verify(eventPublisher).publishEvent(any(ReviewCreatedEvent.class));
         }
 
         @Test
@@ -126,7 +124,7 @@ class ReviewServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.DUPLICATE_REVIEW));
-            verify(bookRepository, never()).increaseReviewCount(any());
+            verify(eventPublisher, never()).publishEvent(any(ReviewCreatedEvent.class));
         }
 
         @Test
@@ -143,7 +141,7 @@ class ReviewServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.USER_NOT_FOUND));
-            verify(bookRepository, never()).increaseReviewCount(any());
+            verify(eventPublisher, never()).publishEvent(any(ReviewCreatedEvent.class));
         }
 
         @Test
@@ -162,7 +160,7 @@ class ReviewServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.BOOK_NOT_FOUND));
-            verify(bookRepository, never()).increaseReviewCount(any());
+            verify(eventPublisher, never()).publishEvent(any(ReviewCreatedEvent.class));
         }
 
     }
@@ -258,11 +256,13 @@ class ReviewServiceTest {
         void updateReview_success() {
             UUID reviewId = UUID.randomUUID();
             UUID userId = UUID.randomUUID();
+            UUID bookId = UUID.randomUUID();
             Review review = mock(Review.class);
+            Book book = mock(Book.class);
             ReviewUpdateRequest request = new ReviewUpdateRequest("수정된 내용", 3);
             ReviewResponse expectedResponse = new ReviewResponse(
                     reviewId,
-                    UUID.randomUUID(),
+                    bookId,
                     "클린 코드",
                     null,
                     userId,
@@ -278,6 +278,9 @@ class ReviewServiceTest {
 
             given(reviewRepository.findByIdAndDeletedAtIsNull(reviewId)).willReturn(Optional.of(review));
             given(review.isOwner(userId)).willReturn(true);
+            given(review.getRating()).willReturn(5);
+            given(review.getBook()).willReturn(book);
+            given(book.getId()).willReturn(bookId);
             given(reviewLikeRepository.existsByReviewIdAndUserId(reviewId, userId)).willReturn(true);
             given(reviewMapper.toResponse(review, true)).willReturn(expectedResponse);
 
@@ -340,11 +343,12 @@ class ReviewServiceTest {
             given(review.isOwner(userId)).willReturn(true);
             given(review.getBook()).willReturn(book);
             given(book.getId()).willReturn(bookId);
+            given(review.getRating()).willReturn(4);
 
             reviewService.softDeleteReview(reviewId, userId);
 
             verify(review).softDelete();
-            verify(bookRepository).decreaseReviewCount(bookId);
+            verify(eventPublisher).publishEvent(any(ReviewDeletedEvent.class));
         }
 
         @Test
@@ -362,7 +366,7 @@ class ReviewServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.REVIEW_NOT_OWNER));
-            verify(bookRepository, never()).decreaseReviewCount(any());
+            verify(eventPublisher, never()).publishEvent(any(ReviewDeletedEvent.class));
         }
 
         @Test
@@ -377,7 +381,7 @@ class ReviewServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.REVIEW_NOT_FOUND));
-            verify(bookRepository, never()).decreaseReviewCount(any());
+            verify(eventPublisher, never()).publishEvent(any(ReviewDeletedEvent.class));
         }
     }
 
@@ -464,10 +468,11 @@ class ReviewServiceTest {
             given(review.getDeletedAt()).willReturn(null);
             given(review.getBook()).willReturn(book);
             given(book.getId()).willReturn(bookId);
+            given(review.getRating()).willReturn(4);
 
             reviewService.hardDeleteReview(reviewId, userId);
 
-            verify(bookRepository).decreaseReviewCount(bookId);
+            verify(eventPublisher).publishEvent(any(ReviewDeletedEvent.class));
             verify(reviewRepository).delete(review);
         }
 
@@ -484,7 +489,7 @@ class ReviewServiceTest {
 
             reviewService.hardDeleteReview(reviewId, userId);
 
-            verify(bookRepository, never()).decreaseReviewCount(any());
+            verify(eventPublisher, never()).publishEvent(any(ReviewDeletedEvent.class));
             verify(reviewRepository).delete(review);
         }
 
@@ -503,7 +508,7 @@ class ReviewServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.REVIEW_NOT_OWNER));
-            verify(bookRepository, never()).decreaseReviewCount(any());
+            verify(eventPublisher, never()).publishEvent(any(ReviewDeletedEvent.class));
         }
 
         @Test
@@ -518,7 +523,7 @@ class ReviewServiceTest {
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(ErrorCode.REVIEW_NOT_FOUND));
-            verify(bookRepository, never()).decreaseReviewCount(any());
+            verify(eventPublisher, never()).publishEvent(any(ReviewDeletedEvent.class));
         }
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewServiceTest.java
@@ -102,7 +102,7 @@ class ReviewServiceTest {
             assertThat(response.content()).isEqualTo("좋은 책입니다");
             assertThat(response.rating()).isEqualTo(5);
             verify(reviewRepository).save(any(Review.class));
-            verify(eventPublisher).publishEvent(any(ReviewCreatedEvent.class));
+            verify(eventPublisher).publishEvent(new ReviewCreatedEvent(bookId, 5));
         }
 
         @Test
@@ -348,7 +348,7 @@ class ReviewServiceTest {
             reviewService.softDeleteReview(reviewId, userId);
 
             verify(review).softDelete();
-            verify(eventPublisher).publishEvent(any(ReviewDeletedEvent.class));
+            verify(eventPublisher).publishEvent(new ReviewDeletedEvent(bookId, 4));
         }
 
         @Test
@@ -472,7 +472,7 @@ class ReviewServiceTest {
 
             reviewService.hardDeleteReview(reviewId, userId);
 
-            verify(eventPublisher).publishEvent(any(ReviewDeletedEvent.class));
+            verify(eventPublisher).publishEvent(new ReviewDeletedEvent(bookId, 4));
             verify(reviewRepository).delete(review);
         }
 


### PR DESCRIPTION
## 관련 이슈
- closes #222

## 작업 내용
- 리뷰 CUD 시 도서 rating, reviewCount에 반영이 안되던 문제
- BookStatistics 도서 집계 테이블 생성
- 이벤트 기반으로 도서 CUD 시 집계 테이블에 반영
- 현재 DB 집계테이블에 반영되는것 까지 확인하여 도서 서비스에서 참조 변경과 테이블 필드 삭제가 필요합니다
- 기존 비정규화 집계 필드를 분리하여 기존 데이터와는 정합성이 틀어지는 상태 입니다 -> truncate 필요

## 변경 사항
  - 리뷰 생성/수정/삭제 시 Spring Event를 발행하여 BookStatistics(리뷰 수, 평균 평점)를 비동기로 집계                                                                                                                              
  - BookStatistics 엔티티, Repository, EventListener 추가 및 Flyway 마이그레이션(V3) 포함
  - @Retryable 기반 재시도 설정 (RetryConfig) 추가   

## 테스트 내용
- [x] 테스트 코드 작성
- [ ] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 도서별 평점 통계 추적 기능 추가
  * 리뷰 생성, 수정, 삭제 시 도서 통계 자동 업데이트
  * 평균 평점 계산 및 표시 기능 추가

* **개선 사항**
  * 재시도 메커니즘으로 통계 업데이트 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->