### PR TITLE
BOOK_STATISTICS 테이블에서 reviewcount, rating 가져오기로 수정

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/book/service/BookQueryService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/book/service/BookQueryService.java
@@ -1,5 +1,6 @@
 package com.codeit.team4.deokhugam.book.service;
 
+import static com.codeit.team4.deokhugam.jooq.Tables.BOOK_STATISTICS;
 import static com.codeit.team4.deokhugam.jooq.tables.Books.BOOKS;
 
 import com.codeit.team4.deokhugam.book.dto.BookResponse;
@@ -130,10 +131,34 @@ public class BookQueryService {
                     : DSL.row(primary, BOOKS.CREATED_AT)
                             .lt((Comparable<?>) cursorValue, afterOffset));
         }
-
         // 최종 쿼리 조립 및 실행
         return dsl
-                .selectFrom(BOOKS)
+                .select(
+                        BOOKS.ID,
+                        BOOKS.TITLE,
+                        BOOKS.AUTHOR,
+                        BOOKS.DESCRIPTION,
+                        BOOKS.PUBLISHER,
+                        BOOKS.PUBLISHED_DATE,
+                        BOOKS.ISBN,
+                        BOOKS.THUMBNAIL_URL,
+                        BOOKS.CREATED_AT,
+                        BOOKS.UPDATED_AT,
+                        DSL.coalesce(BOOK_STATISTICS.REVIEW_COUNT, 0).as("review_count"),
+                        DSL.coalesce(
+                                DSL.when(BOOK_STATISTICS.REVIEW_COUNT.eq(0), BigDecimal.ZERO)
+                                        .otherwise(
+                                                DSL.field("CAST({0} AS DECIMAL(10,2))",
+                                                        BigDecimal.class,
+                                                        BOOK_STATISTICS.RATING_SUM.cast(BigDecimal.class)
+                                                                .divide(BOOK_STATISTICS.REVIEW_COUNT)
+                                                )
+                                        ),
+                                BigDecimal.ZERO
+                        ).as("rating")
+                )
+                .from(BOOKS)
+                .leftJoin(BOOK_STATISTICS).on(BOOKS.ID.eq(BOOK_STATISTICS.BOOK_ID))
                 .where(condition)
                 .orderBy(primarySort, secondarySort)
                 .limit(limit + 1)
@@ -147,9 +172,9 @@ public class BookQueryService {
                         record.get(BOOKS.PUBLISHED_DATE),
                         record.get(BOOKS.ISBN),
                         record.get(BOOKS.THUMBNAIL_URL),
-                        record.get(BOOKS.REVIEW_COUNT),
-                        record.get(BOOKS.RATING),
-                        record.get(BOOKS.CREATED_AT).toInstant(),    // DB 시간을 Java 표준 Instant로 변환
+                        record.get("review_count", Integer.class),
+                        record.get("rating", BigDecimal.class),
+                        record.get(BOOKS.CREATED_AT).toInstant(),   // DB 시간을 Java 표준 Instant로 변환
                         record.get(BOOKS.UPDATED_AT).toInstant()
                 ));
     }
@@ -175,8 +200,11 @@ public class BookQueryService {
     private Field<? extends Comparable<?>> getSortField(String orderBy) {
         return switch (orderBy) {
             case "publishedDate" -> BOOKS.PUBLISHED_DATE;
-            case "rating" -> BOOKS.RATING;
-            case "reviewCount" -> BOOKS.REVIEW_COUNT;
+            case "rating" -> DSL.coalesce(
+                    DSL.when(BOOK_STATISTICS.REVIEW_COUNT.eq(0), BigDecimal.ZERO)
+                            .otherwise(BOOK_STATISTICS.RATING_SUM.cast(BigDecimal.class)
+                                    .divide(BOOK_STATISTICS.REVIEW_COUNT)), BigDecimal.ZERO);
+            case "reviewCount" -> DSL.coalesce(BOOK_STATISTICS.REVIEW_COUNT, 0);
             case "title" -> BOOKS.TITLE;
             default -> throw new IllegalStateException("지원하지 않는 정렬 기준: " + orderBy);
         };

--- a/src/main/java/com/codeit/team4/deokhugam/book/service/BookQueryService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/book/service/BookQueryService.java
@@ -34,6 +34,21 @@ public class BookQueryService {
 
     private final DSLContext dsl;
 
+    private Field<BigDecimal> ratingField() {
+        return DSL.field(
+                "CAST({0} AS DECIMAL(10,2))",
+                BigDecimal.class,
+                DSL.coalesce(
+                        DSL.when(BOOK_STATISTICS.REVIEW_COUNT.eq(0), BigDecimal.ZERO)
+                                .otherwise(
+                                        BOOK_STATISTICS.RATING_SUM.cast(BigDecimal.class)
+                                                .divide(BOOK_STATISTICS.REVIEW_COUNT)
+                                ),
+                        BigDecimal.ZERO
+                )
+        );
+    }
+
     public PageResponse<BookResponse> getBooks(
             String keyword,
             String orderBy,
@@ -145,17 +160,7 @@ public class BookQueryService {
                         BOOKS.CREATED_AT,
                         BOOKS.UPDATED_AT,
                         DSL.coalesce(BOOK_STATISTICS.REVIEW_COUNT, 0).as("review_count"),
-                        DSL.coalesce(
-                                DSL.when(BOOK_STATISTICS.REVIEW_COUNT.eq(0), BigDecimal.ZERO)
-                                        .otherwise(
-                                                DSL.field("CAST({0} AS DECIMAL(10,2))",
-                                                        BigDecimal.class,
-                                                        BOOK_STATISTICS.RATING_SUM.cast(BigDecimal.class)
-                                                                .divide(BOOK_STATISTICS.REVIEW_COUNT)
-                                                )
-                                        ),
-                                BigDecimal.ZERO
-                        ).as("rating")
+                        ratingField().as("rating")
                 )
                 .from(BOOKS)
                 .leftJoin(BOOK_STATISTICS).on(BOOKS.ID.eq(BOOK_STATISTICS.BOOK_ID))
@@ -200,10 +205,7 @@ public class BookQueryService {
     private Field<? extends Comparable<?>> getSortField(String orderBy) {
         return switch (orderBy) {
             case "publishedDate" -> BOOKS.PUBLISHED_DATE;
-            case "rating" -> DSL.coalesce(
-                    DSL.when(BOOK_STATISTICS.REVIEW_COUNT.eq(0), BigDecimal.ZERO)
-                            .otherwise(BOOK_STATISTICS.RATING_SUM.cast(BigDecimal.class)
-                                    .divide(BOOK_STATISTICS.REVIEW_COUNT)), BigDecimal.ZERO);
+            case "rating" -> ratingField();
             case "reviewCount" -> DSL.coalesce(BOOK_STATISTICS.REVIEW_COUNT, 0);
             case "title" -> BOOKS.TITLE;
             default -> throw new IllegalStateException("지원하지 않는 정렬 기준: " + orderBy);
@@ -220,7 +222,8 @@ public class BookQueryService {
     }
 
     private void validateSort(String orderBy, String direction) {
-        if (orderBy == null || !List.of("title", "publishedDate", "rating", "reviewCount").contains(orderBy)) {
+        if (orderBy == null || !List.of("title", "publishedDate", "rating", "reviewCount")
+                .contains(orderBy)) {
             throw new BusinessException(ErrorCode.INVALID_INPUT, "orderBy=" + orderBy);
         }
         if (direction == null || !List.of("ASC", "DESC").contains(direction)) {


### PR DESCRIPTION
## 관련 이슈
- closes #226 

## 작업 내용
- 
- 
- 

## 변경 사항
- 주요 변경 사항을 작성해주세요.

## 테스트 내용
- [ ] 테스트 코드 작성
- [ ] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [ ] 코드 컨벤션을 지켰습니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [ ] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 도서 평점 및 리뷰 수 계산 알고리즘을 개선하여 통계 정보의 정확성을 향상시켰습니다
* 통계 정보가 없는 경우에도 안정적으로 작동하도록 개선
* 평점 및 리뷰 수를 기준으로 도서를 정렬할 때 성능이 최적화되었습니다

<!-- end of auto-generated comment: release notes by coderabbit.ai -->