### PR TITLE
refactor: 알림 이벤트 비동기 처리 구조 개선

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchService.java
@@ -154,9 +154,8 @@ public class DashboardBatchService {
         if (shouldPublish(period, snapshotDate)) {
             for (PopularReview p : popularReviews) {
 
-                if (p.getReview() == null || p.getUser() == null) {
-                    continue;
-                }
+                if (p.getReview() == null || p.getUser() == null) continue;
+                if (p.getRank() > 10) continue;
 
                 eventPublisher.publishEvent(
                         new ReviewRankedEvent(

--- a/src/main/java/com/codeit/team4/deokhugam/global/config/AsyncConfig.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/config/AsyncConfig.java
@@ -1,0 +1,28 @@
+package com.codeit.team4.deokhugam.global.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        executor.setCorePoolSize(10);   // 기본 스레드
+        executor.setMaxPoolSize(30);    // 최대 확장
+        executor.setQueueCapacity(100);  // 대기 큐
+
+        executor.setThreadNamePrefix("async-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
+
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/global/config/AsyncConfig.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/config/AsyncConfig.java
@@ -1,6 +1,7 @@
 package com.codeit.team4.deokhugam.global.config;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -17,6 +18,7 @@ public class AsyncConfig {
         executor.setCorePoolSize(10);   // 기본 스레드
         executor.setMaxPoolSize(30);    // 최대 확장
         executor.setQueueCapacity(100);  // 대기 큐
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
 
         executor.setThreadNamePrefix("async-");
         executor.setWaitForTasksToCompleteOnShutdown(true);

--- a/src/main/java/com/codeit/team4/deokhugam/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/codeit/team4/deokhugam/notification/listener/NotificationEventListener.java
@@ -86,16 +86,19 @@ public class NotificationEventListener {
 
     @Recover
     public void recover(Exception e, LikeEvent event) {
-        log.error("좋아요 알림 최종 실패 (3회 재시도 후): event={}", event, e);
+        log.error("NotificationEvent 최종 실패 (Like): reviewId={}, receiverId={}, actorId={}",
+                event.reviewId(), event.receiverId(), event.actorId(), e);
     }
 
     @Recover
     public void recover(Exception e, CommentEvent event) {
-        log.error("댓글 알림 최종 실패 (3회 재시도 후): event={}", event, e);
+        log.error("NotificationEvent 최종 실패 (Comment): reviewId={}, receiverId={}, actorId={}",
+                event.reviewId(), event.receiverId(), event.actorId(), e);
     }
 
     @Recover
     public void recover(Exception e, ReviewRankedEvent event) {
-        log.error("랭크 알림 최종 실패 (3회 재시도 후): event={}", event, e);
+        log.error("NotificationEvent 최종 실패 (ReviewRanked): reviewId={}, userId={}, rank={}",
+                event.reviewId(), event.receiverId(), event.rank(), e);
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/codeit/team4/deokhugam/notification/listener/NotificationEventListener.java
@@ -7,6 +7,10 @@ import com.codeit.team4.deokhugam.notification.event.ReviewRankedEvent;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -18,45 +22,53 @@ public class NotificationEventListener {
 
     private final NotificationService notificationService;
 
+    @Async("taskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Retryable(
+            retryFor = Exception.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 500)
+    )
     public void handleLikeCreated(LikeEvent event) {
         log.debug("LikeEvent 수신: {}", event);
 
         if (event.receiverId() == null || Objects.equals(event.receiverId(), event.actorId())) {
             return;
         }
-
-        try {
             notificationService.createLikeNotification(
                     event.receiverId(),
                     event.reviewId(),
                     event.actorId()
             );
-        } catch (Exception e) {
-            log.error("좋아요 알림 생성 실패: event={}", event, e);
-        }
     }
 
+    @Async("taskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Retryable(
+            retryFor = Exception.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 500)
+    )
     public void handleCommentCreated(CommentEvent event) {
         log.debug("CommentEvent 수신: {}", event);
 
         if (event.receiverId() == null || Objects.equals(event.receiverId(), event.actorId())) {
             return;
         }
-
-        try {
             notificationService.createCommentNotification(
                     event.receiverId(),
                     event.reviewId(),
                     event.actorId()
             );
-        } catch (Exception e) {
-            log.error("댓글 알림 생성 실패 - event={}", event, e);
-        }
     }
 
+    @Async("taskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Retryable(
+            retryFor = Exception.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 500)
+    )
     public void handleReviewRanked(ReviewRankedEvent event) {
         log.info("ReviewRankedEvent 수신: {}", event);
 
@@ -64,15 +76,26 @@ public class NotificationEventListener {
             log.warn("알림 생성 스킵 - receiverId가 null입니다. event={}", event);
             return;
         }
-        try {
             notificationService.createRankNotification(
                     event.receiverId(),
                     event.reviewId(),
                     event.period(),
                     event.rank()
             );
-        } catch (Exception e) {
-            log.error("랭크 알림 생성 실패: event={}", event, e);
-        }
+    }
+
+    @Recover
+    public void recover(Exception e, LikeEvent event) {
+        log.error("좋아요 알림 최종 실패 (3회 재시도 후): event={}", event, e);
+    }
+
+    @Recover
+    public void recover(Exception e, CommentEvent event) {
+        log.error("댓글 알림 최종 실패 (3회 재시도 후): event={}", event, e);
+    }
+
+    @Recover
+    public void recover(Exception e, ReviewRankedEvent event) {
+        log.error("랭크 알림 최종 실패 (3회 재시도 후): event={}", event, e);
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/notification/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/notification/listener/NotificationEventListenerTest.java
@@ -1,0 +1,180 @@
+package com.codeit.team4.deokhugam.notification.listener;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.*;
+
+import com.codeit.team4.deokhugam.notification.event.CommentEvent;
+import com.codeit.team4.deokhugam.notification.event.LikeEvent;
+import com.codeit.team4.deokhugam.notification.event.ReviewRankedEvent;
+import com.codeit.team4.deokhugam.notification.service.NotificationService;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationEventListenerTest {
+
+    @InjectMocks
+    private NotificationEventListener listener;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Test
+    @DisplayName("좋아요 알림 생성 이벤트 처리 성공")
+    void handleLikeCreated_success() {
+        UUID receiverId = UUID.randomUUID();
+        UUID reviewId = UUID.randomUUID();
+        UUID actorId = UUID.randomUUID();
+
+        LikeEvent event = new LikeEvent(reviewId, receiverId, actorId);
+
+        listener.handleLikeCreated(event);
+
+        verify(notificationService).createLikeNotification(receiverId, reviewId, actorId);
+    }
+
+    @Test
+    @DisplayName("receiverId가 null일 때 좋아요 알림 생성 스킵 성공")
+    void handleLikeCreated_receiverNull_skip() {
+        UUID reviewId = UUID.randomUUID();
+        UUID actorId = UUID.randomUUID();
+
+        LikeEvent event = new LikeEvent(reviewId, null, actorId);
+
+        listener.handleLikeCreated(event);
+
+        verify(notificationService, never()).createLikeNotification(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("본인 좋아요일 때 알림 생성 스킵 성공")
+    void handleLikeCreated_selfLike_skip() {
+        UUID userId = UUID.randomUUID();
+        UUID reviewId = UUID.randomUUID();
+
+        LikeEvent event = new LikeEvent(reviewId, userId, userId);
+
+        listener.handleLikeCreated(event);
+
+        verify(notificationService, never()).createLikeNotification(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("좋아요 알림 생성 중 예외 발생")
+    void handleLikeCreated_exception() {
+        UUID receiverId = UUID.randomUUID();
+        UUID reviewId = UUID.randomUUID();
+        UUID actorId = UUID.randomUUID();
+
+        LikeEvent event = new LikeEvent(reviewId, receiverId, actorId);
+
+        doThrow(new RuntimeException("실패"))
+                .when(notificationService)
+                .createLikeNotification(receiverId, reviewId, actorId);
+
+        assertThatCode(() -> listener.handleLikeCreated(event))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    @DisplayName("댓글 알림 생성 이벤트 처리 성공")
+    void handleCommentCreated_success() {
+        UUID receiverId = UUID.randomUUID();
+        UUID reviewId = UUID.randomUUID();
+        UUID actorId = UUID.randomUUID();
+
+        CommentEvent event = new CommentEvent(reviewId, receiverId, actorId);
+
+        listener.handleCommentCreated(event);
+
+        verify(notificationService).createCommentNotification(receiverId, reviewId, actorId);
+    }
+
+    @Test
+    @DisplayName("receiverId가 null일 때 댓글 알림 생성 스킵 성공")
+    void handleCommentCreated_receiverNull_skip() {
+        UUID reviewId = UUID.randomUUID();
+        UUID actorId = UUID.randomUUID();
+
+        CommentEvent event = new CommentEvent(reviewId, null, actorId);
+
+        listener.handleCommentCreated(event);
+
+        verify(notificationService, never()).createCommentNotification(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("본인 댓글일 때 알림 생성 스킵 성공")
+    void handleCommentCreated_self_skip() {
+        UUID userId = UUID.randomUUID();
+        UUID reviewId = UUID.randomUUID();
+
+        CommentEvent event = new CommentEvent(reviewId, userId, userId);
+
+        listener.handleCommentCreated(event);
+
+        verify(notificationService, never()).createCommentNotification(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("랭크 알림 생성 이벤트 처리 성공")
+    void handleReviewRanked_success() {
+        UUID receiverId = UUID.randomUUID();
+        UUID reviewId = UUID.randomUUID();
+
+        ReviewRankedEvent event =
+                new ReviewRankedEvent(reviewId, receiverId, null, 1, null);
+
+        listener.handleReviewRanked(event);
+
+        verify(notificationService)
+                .createRankNotification(receiverId, reviewId, null, 1);
+    }
+
+    @Test
+    @DisplayName("receiverId가 null일 때 랭크 알림 생성 스킵 성공")
+    void handleReviewRanked_receiverNull_skip() {
+        UUID reviewId = UUID.randomUUID();
+
+        ReviewRankedEvent event =
+                new ReviewRankedEvent(reviewId, null, null, 1, null);
+
+        listener.handleReviewRanked(event);
+
+        verify(notificationService, never())
+                .createRankNotification(any(), any(), any(), anyInt());
+    }
+
+    @Test
+    @DisplayName("LikeEvent recover 시 예외 전파 없이 종료 성공")
+    void recover_like_success() {
+        LikeEvent event = new LikeEvent(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+
+        assertThatCode(() -> listener.recover(new RuntimeException("실패"), event))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("CommentEvent recover 시 예외 전파 없이 종료 성공")
+    void recover_comment_success() {
+        CommentEvent event = new CommentEvent(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+
+        assertThatCode(() -> listener.recover(new RuntimeException("실패"), event))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("ReviewRankedEvent recover 시 예외 전파 없이 종료 성공")
+    void recover_rank_success() {
+        ReviewRankedEvent event =
+                new ReviewRankedEvent(UUID.randomUUID(), UUID.randomUUID(), null, 1, null);
+
+        assertThatCode(() -> listener.recover(new RuntimeException("실패"), event))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/codeit/team4/deokhugam/notification/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/notification/listener/NotificationEventListenerTest.java
@@ -65,8 +65,8 @@ class NotificationEventListenerTest {
     }
 
     @Test
-    @DisplayName("좋아요 알림 생성 중 예외 발생")
-    void handleLikeCreated_exception() {
+    @DisplayName("좋아요 알림 생성 실패")
+    void handleLikeCreated_serviceThrowFailure() {
         UUID receiverId = UUID.randomUUID();
         UUID reviewId = UUID.randomUUID();
         UUID actorId = UUID.randomUUID();


### PR DESCRIPTION
## 관련 이슈
- closes #241 

## 작업 내용
- 알림 이벤트 처리 구조를 `@Async` 기반 비동기 방식으로 변경
- ThreadPoolTaskExecutor(taskExecutor) 설정 추가
- Like / Comment / ReviewRanked 이벤트 비동기 처리 적용
- Transaction AFTER_COMMIT 이후 이벤트 처리 유지
- Retry / Recover 전략 추가
- TOP10 리뷰에 대해서만 알림 발행하도록 정책 제한 적용

## 변경 사항
- 요구사항에 따르면 인기 리뷰 top10에 해당되는 사용자에게 알림이 가게끔 구현하라고 되어있었는데, 제가 조건식을 누락해서 top20 까지 알림이 가고 있었습니다.
- 간단한 조건식 추가로 top10 인원들에게만 알림이 가게 변경했습니다.
- 리스너에 대한 테스트 코드를 작성했습니다.

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 알림 처리의 비동기 실행 추가로 응답성 개선
  * 작업 실행을 위한 전용 실행기 등록

* **개선사항**
  * 알림 전송 실패 시 자동 재시도(최대 재시도 및 백오프) 도입으로 신뢰성 향상
  * 인기 리뷰 이벤트 발행 대상에 상위 10위 필터 적용하여 이벤트 정확도 향상

* **테스트**
  * 비동기 알림 처리와 복구 동작을 검증하는 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->