### PR TITLE
fix: UserCleanupScheduler에 zone 추가

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/user/scheduler/UserCleanupScheduler.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/scheduler/UserCleanupScheduler.java
@@ -13,7 +13,7 @@ public class UserCleanupScheduler {
 
     private final UserService userService;
 
-    @Scheduled(cron = "${user.cleanup.cron}")
+    @Scheduled(cron = "${user.cleanup.cron}", zone = "${user.cleanup.zone}")
     public void runCleanup() {
         log.info("유저 물리 삭제 스케줄러 시작");
         try {


### PR DESCRIPTION
## 관련 이슈
- closes #262 

## 작업 내용
- UserCleanupScheduler에 cron 설정 안에 있는 zone이 누락 되어 있어서 추가하는 작업을 진행했습니다.

## 변경 사항
- 주요 변경 사항을 작성해주세요.

## 테스트 내용
- [ ] 테스트 코드 작성
- [ ] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [ ] 코드 컨벤션을 지켰습니다.
- [ ] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [ ] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 사용자 정리 스케줄러가 이제 구성 가능한 시간대를 지원합니다. 백그라운드 정리 작업이 설정된 시간대에 따라 정확하게 실행되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->