### PR TITLE
feat: User PasswordEncoder 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jooq'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.security:spring-security-crypto'
     implementation 'org.redisson:redisson-spring-boot-starter:3.50.0'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.retry:spring-retry'

--- a/src/main/java/com/codeit/team4/deokhugam/global/config/SecurityConfig.java
+++ b/src/main/java/com/codeit/team4/deokhugam/global/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.codeit.team4.deokhugam.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/user/service/UserService.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +31,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserQueryService userQueryService;
     private final UserMapper userMapper;
+    private final PasswordEncoder passwordEncoder;
 
     public UserResponse getUser(UUID userId) {
 
@@ -45,7 +47,13 @@ public class UserService {
         validateEmailNotExists(request.email());
 
         try {
-            User user = new User(request.email(), request.nickname(), request.password());
+            String encodedPassword = passwordEncoder.encode(request.password());
+
+            User user = new User(
+                    request.email(),
+                    request.nickname(),
+                    encodedPassword
+            );
             User savedUser = userRepository.save(user);
 
             log.info("회원가입 성공: userId={}", savedUser.getId());
@@ -142,7 +150,7 @@ public class UserService {
     }
 
     private void validatePassword(User user, String password) {
-        if (!Objects.equals(user.getPassword(), password)) {
+        if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new BusinessException(ErrorCode.INVALID_PASSWORD, "userId=" + user.getId());
         }
     }

--- a/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceTest.java
@@ -30,9 +30,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
-class UserServiceImplTest {
+class UserServiceTest {
 
     @Mock
     private UserRepository userRepository;
@@ -46,6 +47,9 @@ class UserServiceImplTest {
     @InjectMocks
     private UserService userService;
 
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
     @Test
     @DisplayName("회원가입 성공")
     void registerUser_success() {
@@ -55,10 +59,13 @@ class UserServiceImplTest {
                 "user1",
                 "password1!"
         );
-        User savedUser = new User("test@test.com", "user1", "password1!");
+        User savedUser = new User("test@test.com", "user1", "encodedPassword");
 
         when(userRepository.existsByEmailAndDeletedAtIsNull(request.email()))
                 .thenReturn(false);
+
+        when(passwordEncoder.encode("password1!"))
+                .thenReturn("encodedPassword");
 
         when(userRepository.save(any(User.class)))
                 .thenReturn(savedUser);
@@ -113,6 +120,9 @@ class UserServiceImplTest {
         when(userRepository.existsByEmailAndDeletedAtIsNull(request.email()))
                 .thenReturn(false);
 
+        when(passwordEncoder.encode("password1!"))
+                .thenReturn("encodedPassword");
+
         when(userRepository.save(any(User.class)))
                 .thenThrow(new DataIntegrityViolationException("duplicate"));
 
@@ -138,6 +148,9 @@ class UserServiceImplTest {
         when(userRepository.existsByEmailAndDeletedAtIsNull(request.email()))
                 .thenReturn(false);
 
+        when(passwordEncoder.encode("password1!"))
+                .thenReturn("encodedPassword");
+
         when(userRepository.save(any(User.class)))
                 .thenThrow(new RuntimeException("DB crash"));
 
@@ -155,10 +168,13 @@ class UserServiceImplTest {
     void loginUser_success() {
         // given
         UserLoginRequest request = new UserLoginRequest("test@test.com", "password1!");
-        User user = new User("test@test.com", "user1", "password1!");
+        User user = new User("test@test.com", "user1", "encodedPassword");
 
         when(userRepository.findByEmailAndDeletedAtIsNull(request.email()))
                 .thenReturn(Optional.of(user));
+
+        when(passwordEncoder.matches("password1!", "encodedPassword"))
+                .thenReturn(true);
 
         when(userMapper.toResponse(user))
                 .thenReturn(new UserResponse(user.getId(), user.getEmail(), user.getNickname(), null));
@@ -194,10 +210,13 @@ class UserServiceImplTest {
     void loginUser_fail_invalid_password() {
         // given
         UserLoginRequest request = new UserLoginRequest("test@test.com", "wrongPassword");
-        User user = new User("test@test.com", "user1", "password1!");
+        User user = new User("test@test.com", "user1", "encodedPassword");
 
         when(userRepository.findByEmailAndDeletedAtIsNull(request.email()))
                 .thenReturn(Optional.of(user));
+
+        when(passwordEncoder.matches("wrongPassword", "encodedPassword"))
+                .thenReturn(false);
 
         // when & then
         assertThatThrownBy(() -> userService.loginUser(request))

--- a/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/user/service/UserServiceTest.java
@@ -86,6 +86,40 @@ class UserServiceTest {
     }
 
     @Test
+    @DisplayName("비밀번호가 정상적으로 암호화되어 회원가입 성공")
+    void registerUser_passwordEncoded_success() {
+        // given
+        UserRegisterRequest request = new UserRegisterRequest(
+                "test@test.com",
+                "user1",
+                "password1!"
+        );
+
+        when(userRepository.existsByEmailAndDeletedAtIsNull(request.email()))
+                .thenReturn(false);
+
+        when(passwordEncoder.encode("password1!"))
+                .thenReturn("encodedPassword");
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+
+        when(userRepository.save(any(User.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        userService.registerUser(request);
+
+        // then
+        verify(userRepository).save(captor.capture());
+
+        User savedUser = captor.getValue();
+
+        assertThat(savedUser.getPassword()).isEqualTo("encodedPassword");
+
+        verify(passwordEncoder).encode("password1!");
+    }
+
+    @Test
     @DisplayName("이메일 중복으로 인한 회원가입 실패")
     void registerUser_fail_duplicate_email() {
         // given


### PR DESCRIPTION
## 관련 이슈
- closes #264 

## 작업 내용
- 회원가입 시 평문 비밀번호를 PasswordEncoder로 암호화하여 저장하도록 변경했습니다.
- 로그인 시 PasswordEncoder.matches()를 사용해 비밀번호를 검증하도록 수정했습니다.
- 변경된 로직에 따라서 회원가입, 로그인 테스트 코드 일부를 수정하였습니다.

## 변경 사항
- PasswordEncoder를 적용하기 위해서 다음과 같은 의존성을 추가했습니다.
```java
  implementation 'org.springframework.security:spring-security-crypto'
```
- global/config에 `SecurityConfig.java`를 추가했습니다.
- 로그인 로직이 변경되어서 기존에 DB에 있던 계정은 로그인이 안되니 참고해주시길 바랍니다.

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [ ] 주석이 필요한 부분에 추가했습니다.
- [ ] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 사용자 패스워드 보안 강화: 패스워드가 이제 안전한 암호화 알고리즘으로 저장되며, 로그인 시 검증 프로세스가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->