### PR TITLE
feat: 도서 상세 조회 시 집계 테이블(BookStatistics)에서 reviewCount, rating을 가져오게 수정

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/book/mapper/BookMapper.java
+++ b/src/main/java/com/codeit/team4/deokhugam/book/mapper/BookMapper.java
@@ -7,22 +7,18 @@ import com.codeit.team4.deokhugam.naver.NaverBookResponse;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.math.BigDecimal;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface BookMapper {
 
-    BookResponse toResponse(Book book);
+    BookResponse toResponse(Book book, int reviewCount, BigDecimal rating);
 
-    @Mapping(target = "id", ignore = true)
-    @Mapping(target = "publishedDate", expression = "java(parsePubdate(item.pubdate()))")
-    @Mapping(target = "thumbnailUrl", source = "thumbnailBase64")
-    @Mapping(target = "reviewCount", constant = "0")
-    @Mapping(target = "rating", expression = "java(java.math.BigDecimal.ZERO)")
-    @Mapping(target = "createdAt", ignore = true)
-    @Mapping(target = "updatedAt", ignore = true)
-    BookResponse toBookResponse(NaverBookResponse.NaverBookItem item, String thumbnailBase64);
+    default BookResponse toResponse(Book book) {
+        return toResponse(book, 0, BigDecimal.ZERO);
+    }
 
     @Mapping(target = "publishedDate", expression = "java(parsePubdate(item.pubdate()))")
     @Mapping(source = "item.isbn", target = "isbn")

--- a/src/main/java/com/codeit/team4/deokhugam/book/service/BookService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/book/service/BookService.java
@@ -7,6 +7,7 @@ import com.codeit.team4.deokhugam.book.dto.NaverBookSearchResponse;
 import com.codeit.team4.deokhugam.book.entity.Book;
 import com.codeit.team4.deokhugam.book.mapper.BookMapper;
 import com.codeit.team4.deokhugam.book.repository.BookRepository;
+import com.codeit.team4.deokhugam.book.repository.BookStatisticsRepository;
 import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.global.error.ErrorCode;
 import com.codeit.team4.deokhugam.global.lock.DistributedLock;
@@ -35,6 +36,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class BookService {
 
     private final BookRepository bookRepository;
+    private final BookStatisticsRepository bookStatisticsRepository;
     private final BookMapper bookMapper;
     private final NaverBookClient naverBookClient;
     private final S3Service s3Service;
@@ -72,8 +74,7 @@ public class BookService {
         log.info("도서 등록 완료: bookId={}", book.getId());
 
         // dto 변환
-        BookResponse bookResponse = bookMapper.toResponse(book);
-        return bookResponse;
+        return bookMapper.toResponse(book);
     }
 
     @Transactional(readOnly = true)
@@ -111,7 +112,7 @@ public class BookService {
                 newThumbnailUrl != null ? newThumbnailUrl : book.getThumbnailUrl());
 
         log.info("도서 수정 완료: bookId={}", bookId);
-        return bookMapper.toResponse(book);
+        return toBookResponse(book);
     }
 
     private void registerS3CleanUp(String newUrl, String oldUrl) {
@@ -144,6 +145,12 @@ public class BookService {
         });
     }
 
+    private BookResponse toBookResponse(Book book) {
+        return bookStatisticsRepository.findById(book.getId())
+                .map(stats -> bookMapper.toResponse(book, stats.getReviewCount(), stats.getAverageRating()))
+                .orElseGet(() -> bookMapper.toResponse(book));
+    }
+
     @DistributedLock(key = "deokhugam:book", lockParam = {"bookId"})
     @Transactional
     public void deleteBook(UUID bookId) {
@@ -169,7 +176,7 @@ public class BookService {
         Book book = bookRepository.findByIdAndDeletedAtIsNull(bookId).orElseThrow(
                 () -> new BusinessException(ErrorCode.BOOK_NOT_FOUND, "bookId=" + bookId));
 
-        BookResponse bookResponse = bookMapper.toResponse(book);
+        BookResponse bookResponse = toBookResponse(book);
         log.info("도서 단건 조회 완료: bookId={}", bookId);
         return bookResponse;
     }

--- a/src/test/java/com/codeit/team4/deokhugam/book/service/BookServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/book/service/BookServiceTest.java
@@ -9,7 +9,10 @@ import com.codeit.team4.deokhugam.book.dto.BookResponse;
 import com.codeit.team4.deokhugam.book.dto.BookUpdateRequest;
 import com.codeit.team4.deokhugam.book.dto.NaverBookSearchResponse;
 import com.codeit.team4.deokhugam.book.entity.Book;
+import com.codeit.team4.deokhugam.book.entity.BookStatistics;
 import com.codeit.team4.deokhugam.book.repository.BookRepository;
+import com.codeit.team4.deokhugam.book.repository.BookStatisticsRepository;
+import java.math.BigDecimal;
 import com.codeit.team4.deokhugam.config.TestContainerConfig;
 import com.codeit.team4.deokhugam.global.error.BusinessException;
 import com.codeit.team4.deokhugam.global.error.ErrorCode;
@@ -33,6 +36,9 @@ class BookServiceTest {
 
     @Autowired
     BookRepository bookRepository;
+
+    @Autowired
+    BookStatisticsRepository bookStatisticsRepository;
 
     @Autowired
     BookService bookService;
@@ -206,12 +212,32 @@ class BookServiceTest {
         assertThat(result.id()).isEqualTo(bookId);
         assertThat(result.title()).isEqualTo(book.title());
         assertThat(result.author()).isEqualTo(book.author());
+        assertThat(result.reviewCount()).isZero();
+        assertThat(result.rating()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
 
-        // DB 확인
-        Book savedBook = bookRepository.findByIdAndDeletedAtIsNull(bookId).orElseThrow();
-        assertThat(savedBook.getId()).isEqualTo(result.id());
-        assertThat(savedBook.getTitle()).isEqualTo(result.title());
-        assertThat(savedBook.getAuthor()).isEqualTo(result.author());
+    @Test
+    @DisplayName("도서 조회 시 통계 반영 성공")
+    void get_detail_with_statistics_success() {
+        // given
+        BookCreateRequest request = new BookCreateRequest(
+                "통계 테스트 책", "저자", "설명",
+                "출판사", LocalDate.of(2026, 1, 1),
+                "9788955823509"
+        );
+        BookResponse book = bookService.createBook(request, null);
+
+        BookStatistics stats = new BookStatistics(book.id());
+        stats.onReviewCreated(5);
+        stats.onReviewCreated(3);
+        bookStatisticsRepository.saveAndFlush(stats);
+
+        // when
+        BookResponse result = bookService.getBook(book.id());
+
+        // then
+        assertThat(result.reviewCount()).isEqualTo(2);
+        assertThat(result.rating()).isEqualByComparingTo(new BigDecimal("4.00"));
     }
 
     @Test


### PR DESCRIPTION
## 관련 이슈
- closes #266

## 작업 내용
- 도서 상세 조회 시 집계 테이블에서 reviewCount, rating을 가져오게 수정

## 변경 사항
- BookMapper 에 파라미터 추가
- BookResponse 반환 시 reviewCount 와rating 을 가져오게 수정

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 도서 상세 정보 응답에 리뷰 수와 평점이 이제 포함됩니다. 통계 데이터가 없는 경우 기본값(리뷰 0개, 평점 0)을 사용합니다.
  * 도서 조회 시 관련 통계 정보를 올바르게 연동하도록 개선했습니다.

* **테스트**
  * 도서 통계 검증을 위한 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->