### PR TITLE
fix: ReviewService 에서 ReviewStatistics를 조회하게 수정

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentQueryService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentQueryService.java
@@ -1,7 +1,7 @@
 package com.codeit.team4.deokhugam.comment.service;
 
 import static com.codeit.team4.deokhugam.jooq.tables.Comments.COMMENTS;
-import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
+import static com.codeit.team4.deokhugam.jooq.tables.ReviewStatistics.REVIEW_STATISTICS;
 import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
 
 import com.codeit.team4.deokhugam.comment.dto.CommentResponse;
@@ -139,9 +139,9 @@ public class CommentQueryService {
 
     private long fetchReviewCommentCount(UUID reviewId) {
         return Optional.ofNullable(
-                dsl.select(REVIEWS.COMMENT_COUNT)
-                        .from(REVIEWS)
-                        .where(REVIEWS.ID.eq(reviewId))
+                dsl.select(REVIEW_STATISTICS.COMMENT_COUNT)
+                        .from(REVIEW_STATISTICS)
+                        .where(REVIEW_STATISTICS.REVIEW_ID.eq(reviewId))
                         .fetchOneInto(Long.class)
         ).orElse(0L);
     }

--- a/src/main/java/com/codeit/team4/deokhugam/review/entity/Review.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/entity/Review.java
@@ -53,9 +53,6 @@ public class Review extends BaseUpdatableEntity {
     @Column(nullable = false)
     private int likeCount;
 
-    @Column(nullable = false)
-    private int commentCount;
-
     @Column(name = "deleted_at")
     private Instant deletedAt;
 
@@ -66,7 +63,6 @@ public class Review extends BaseUpdatableEntity {
         this.content = content;
         this.rating = rating;
         this.likeCount = 0;
-        this.commentCount = 0;
     }
 
     public void update(String content, int rating) {

--- a/src/main/java/com/codeit/team4/deokhugam/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/mapper/ReviewMapper.java
@@ -14,7 +14,11 @@ public interface ReviewMapper {
     @Mapping(source = "review.book.thumbnailUrl", target = "bookThumbnailUrl")
     @Mapping(source = "review.user.id", target = "userId")
     @Mapping(source = "review.user.nickname", target = "userNickname")
-    ReviewResponse toResponse(Review review, boolean likedByMe);
+    ReviewResponse toResponse(Review review, boolean likedByMe, int commentCount);
+
+    default ReviewResponse toResponse(Review review) {
+        return toResponse(review, false, 0);
+    }
 
     ReviewResponse toResponse(ReviewSearchModel model);
 }

--- a/src/main/java/com/codeit/team4/deokhugam/review/model/ReviewSearchModel.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/model/ReviewSearchModel.java
@@ -2,6 +2,7 @@ package com.codeit.team4.deokhugam.review.model;
 
 import static com.codeit.team4.deokhugam.jooq.tables.Books.BOOKS;
 import static com.codeit.team4.deokhugam.jooq.tables.ReviewLikes.REVIEW_LIKES;
+import static com.codeit.team4.deokhugam.jooq.tables.ReviewStatistics.REVIEW_STATISTICS;
 import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
 import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
 
@@ -47,7 +48,7 @@ public record ReviewSearchModel(
                 REVIEWS.CONTENT,
                 REVIEWS.RATING,
                 REVIEWS.LIKE_COUNT,
-                REVIEWS.COMMENT_COUNT,
+                DSL.coalesce(REVIEW_STATISTICS.COMMENT_COUNT, 0).as("comment_count"),
                 likedByMe,
                 REVIEWS.CREATED_AT,
                 REVIEWS.UPDATED_AT
@@ -65,7 +66,7 @@ public record ReviewSearchModel(
                 rec.get(REVIEWS.CONTENT),
                 rec.get(REVIEWS.RATING),
                 rec.get(REVIEWS.LIKE_COUNT),
-                rec.get(REVIEWS.COMMENT_COUNT),
+                rec.get("comment_count", Integer.class),
                 rec.get(DSL.field("liked_by_me", Boolean.class)),
                 rec.get(REVIEWS.CREATED_AT).toInstant(),
                 rec.get(REVIEWS.UPDATED_AT).toInstant()

--- a/src/main/java/com/codeit/team4/deokhugam/review/repository/ReviewRepository.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/repository/ReviewRepository.java
@@ -16,15 +16,6 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     @Query("SELECT r FROM Review r JOIN FETCH r.book JOIN FETCH r.user WHERE r.id = :id AND r.deletedAt IS NULL")
     Optional<Review> findByIdAndDeletedAtIsNull(@Param("id") UUID id);
 
-    // 동시성 제어 + 서버 부하를 고려해 원자적 UPDATE 처리
-    @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("UPDATE Review r SET r.commentCount = r.commentCount + 1 WHERE r.id = :reviewId")
-    void increaseCommentCount(@Param("reviewId") UUID reviewId);
-
-    @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("UPDATE Review r SET r.commentCount = r.commentCount - 1 WHERE r.id = :reviewId AND r.commentCount > 0")
-    void decreaseCommentCount(@Param("reviewId") UUID reviewId);
-
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("UPDATE Review r SET r.likeCount = r.likeCount + 1 WHERE r.id = :reviewId")
     void increaseLikeCount(@Param("reviewId") UUID reviewId);

--- a/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewQueryService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewQueryService.java
@@ -1,6 +1,7 @@
 package com.codeit.team4.deokhugam.review.service;
 
 import static com.codeit.team4.deokhugam.jooq.tables.Books.BOOKS;
+import static com.codeit.team4.deokhugam.jooq.tables.ReviewStatistics.REVIEW_STATISTICS;
 import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
 import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
 
@@ -30,6 +31,7 @@ public class ReviewQueryService {
                 .from(REVIEWS)
                 .join(BOOKS).on(REVIEWS.BOOK_ID.eq(BOOKS.ID))
                 .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
+                .leftJoin(REVIEW_STATISTICS).on(REVIEW_STATISTICS.REVIEW_ID.eq(REVIEWS.ID))
                 .where(queryBuilder.buildCondition(param))
                 .orderBy(queryBuilder.buildOrderBy(param))
                 .limit(param.limit() + 1) // +1로 다음 페이지 존재 여부(hasNext) 판단

--- a/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/review/service/ReviewService.java
@@ -15,9 +15,11 @@ import com.codeit.team4.deokhugam.review.dto.ReviewResponse;
 import com.codeit.team4.deokhugam.review.dto.ReviewUpdateRequest;
 import com.codeit.team4.deokhugam.review.entity.ReviewLike;
 import com.codeit.team4.deokhugam.review.entity.Review;
+import com.codeit.team4.deokhugam.review.entity.ReviewStatistics;
 import com.codeit.team4.deokhugam.review.mapper.ReviewMapper;
 import com.codeit.team4.deokhugam.review.repository.ReviewLikeRepository;
 import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
+import com.codeit.team4.deokhugam.review.repository.ReviewStatisticsRepository;
 import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.service.UserService;
 import java.util.List;
@@ -35,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReviewService {
 
     private final ReviewRepository reviewRepository;
+    private final ReviewStatisticsRepository reviewStatisticsRepository;
     private final ReviewLikeRepository reviewLikeRepository;
     private final UserService userService;
     private final BookService bookService;
@@ -43,7 +46,7 @@ public class ReviewService {
 
     public ReviewResponse getReview(UUID reviewId, UUID userId) {
         Review review = findById(reviewId);
-        return reviewMapper.toResponse(review, isLikedByUser(reviewId, userId));
+        return toReviewResponse(review, userId);
     }
 
     @Transactional
@@ -60,7 +63,7 @@ public class ReviewService {
         eventPublisher.publishEvent(new ReviewCreatedEvent(book.getId(), request.rating()));
         log.info("리뷰 생성 완료: reviewId={}", review.getId());
 
-        return reviewMapper.toResponse(review, false);
+        return reviewMapper.toResponse(review);
     }
 
     public Review findById(UUID reviewId) {
@@ -89,7 +92,7 @@ public class ReviewService {
         }
         log.info("리뷰 수정 완료: reviewId={}", review.getId());
 
-        return reviewMapper.toResponse(review, isLikedByUser(reviewId, userId));
+        return toReviewResponse(review, userId);
     }
 
     @Transactional
@@ -166,8 +169,14 @@ public class ReviewService {
         log.info("리뷰 좋아요 취소: reviewId={}, userId={}", reviewId, userId);
     }
 
-    private boolean isLikedByUser(UUID reviewId, UUID userId) {
-        return reviewLikeRepository.existsByReviewIdAndUserId(reviewId, userId);
+    private ReviewResponse toReviewResponse(Review review, UUID userId) {
+        return reviewMapper.toResponse(
+                review,
+                reviewLikeRepository.existsByReviewIdAndUserId(review.getId(), userId),
+                reviewStatisticsRepository.findById(review.getId())
+                        .map(ReviewStatistics::getCommentCount)
+                        .orElse(0)
+        );
     }
 
     private Review findWithDeletedById(UUID reviewId) {

--- a/src/main/resources/db/migration/V6__drop_reviews_comment_count.sql
+++ b/src/main/resources/db/migration/V6__drop_reviews_comment_count.sql
@@ -1,1 +1,0 @@
-ALTER TABLE reviews DROP COLUMN comment_count;

--- a/src/main/resources/db/migration/V6__drop_reviews_comment_count.sql
+++ b/src/main/resources/db/migration/V6__drop_reviews_comment_count.sql
@@ -1,0 +1,1 @@
+ALTER TABLE reviews DROP COLUMN comment_count;

--- a/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentQueryServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentQueryServiceTest.java
@@ -15,7 +15,9 @@ import com.codeit.team4.deokhugam.global.error.ErrorCode;
 import com.codeit.team4.deokhugam.global.response.PageResponse;
 import com.codeit.team4.deokhugam.global.response.SortDirection;
 import com.codeit.team4.deokhugam.review.entity.Review;
+import com.codeit.team4.deokhugam.review.entity.ReviewStatistics;
 import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
+import com.codeit.team4.deokhugam.review.repository.ReviewStatisticsRepository;
 import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.repository.UserRepository;
 import java.time.Instant;
@@ -52,6 +54,9 @@ class CommentQueryServiceTest {
 
     @Autowired
     private BookRepository bookRepository;
+
+    @Autowired
+    private ReviewStatisticsRepository reviewStatisticsRepository;
 
     private User user;
     private Review review;
@@ -150,11 +155,13 @@ class CommentQueryServiceTest {
         void getComments_FirstPage_Success() {
             // given: 댓글 3개 생성, 사이즈 2로 조회
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 1"));
-            reviewRepository.increaseCommentCount(review.getId());
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 2"));
-            reviewRepository.increaseCommentCount(review.getId());
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 3"));
-            reviewRepository.increaseCommentCount(review.getId());
+            ReviewStatistics stats = new ReviewStatistics(review.getId());
+            stats.onCommentCreated();
+            stats.onCommentCreated();
+            stats.onCommentCreated();
+            reviewStatisticsRepository.saveAndFlush(stats);
 
             CommentSearchRequestParam param = new CommentSearchRequestParam(
                     review.getId(), SortDirection.DESC, null, null, 2
@@ -176,11 +183,13 @@ class CommentQueryServiceTest {
         void getComments_CursorPagination_Success() {
             // given
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 1"));
-            reviewRepository.increaseCommentCount(review.getId());
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 2"));
-            reviewRepository.increaseCommentCount(review.getId());
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 3"));
-            reviewRepository.increaseCommentCount(review.getId());
+            ReviewStatistics stats = new ReviewStatistics(review.getId());
+            stats.onCommentCreated();
+            stats.onCommentCreated();
+            stats.onCommentCreated();
+            reviewStatisticsRepository.saveAndFlush(stats);
 
             CommentSearchRequestParam firstReq = new CommentSearchRequestParam(
                     review.getId(), SortDirection.DESC, null, null, 2

--- a/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentServiceTest.java
@@ -275,7 +275,6 @@ class CommentServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.COMMENT_NOT_OWNER);
 
         verify(commentRepository, never()).softDeleteWithCondition(any(), any());
-        verify(reviewRepository, never()).decreaseCommentCount(any());
         verify(eventPublisher, never()).publishEvent(any(CommentDeletedEvent.class));
     }
 

--- a/src/test/java/com/codeit/team4/deokhugam/review/entity/ReviewTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/entity/ReviewTest.java
@@ -30,7 +30,6 @@ class ReviewTest {
         assertThat(review.getRating()).isEqualTo(rating);
         assertThat(review.getContent()).isEqualTo("좋은 책입니다");
         assertThat(review.getLikeCount()).isZero();
-        assertThat(review.getCommentCount()).isZero();
     }
 
     @ParameterizedTest

--- a/src/test/java/com/codeit/team4/deokhugam/review/mapper/ReviewMapperTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/mapper/ReviewMapperTest.java
@@ -7,7 +7,9 @@ import static org.mockito.Mockito.mock;
 import com.codeit.team4.deokhugam.book.entity.Book;
 import com.codeit.team4.deokhugam.review.dto.ReviewResponse;
 import com.codeit.team4.deokhugam.review.entity.Review;
+import com.codeit.team4.deokhugam.review.model.ReviewSearchModel;
 import com.codeit.team4.deokhugam.user.entity.User;
+import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,7 +34,7 @@ class ReviewMapperTest {
 
         Review review = new Review(book, user, "좋은 책입니다", 5);
 
-        ReviewResponse response = reviewMapper.toResponse(review, true);
+        ReviewResponse response = reviewMapper.toResponse(review, true, 0);
 
         assertThat(response.bookId()).isEqualTo(bookId);
         assertThat(response.bookTitle()).isEqualTo("클린 코드");
@@ -53,7 +55,7 @@ class ReviewMapperTest {
         User user = mock(User.class);
         Review review = new Review(book, user, "좋은 책입니다", 5);
 
-        ReviewResponse response = reviewMapper.toResponse(review, false);
+        ReviewResponse response = reviewMapper.toResponse(review, false, 0);
 
         assertThat(response.likedByMe()).isFalse();
     }
@@ -65,8 +67,60 @@ class ReviewMapperTest {
         User user = mock(User.class);
         Review review = new Review(book, user, "좋은 책입니다", 5);
 
-        ReviewResponse response = reviewMapper.toResponse(review, true);
+        ReviewResponse response = reviewMapper.toResponse(review, true, 0);
 
+        assertThat(response.likedByMe()).isTrue();
+    }
+
+    @Test
+    @DisplayName("commentCount 전달 값 매핑 성공")
+    void toResponse_withCommentCount_success() {
+        Book book = mock(Book.class);
+        User user = mock(User.class);
+        Review review = new Review(book, user, "좋은 책입니다", 5);
+
+        ReviewResponse response = reviewMapper.toResponse(review, false, 7);
+
+        assertThat(response.commentCount()).isEqualTo(7);
+    }
+
+    @Test
+    @DisplayName("default 메서드 기본값 매핑 성공")
+    void toResponse_default_success() {
+        Book book = mock(Book.class);
+        User user = mock(User.class);
+        Review review = new Review(book, user, "좋은 책입니다", 5);
+
+        ReviewResponse response = reviewMapper.toResponse(review);
+
+        assertThat(response.likedByMe()).isFalse();
+        assertThat(response.commentCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("ReviewSearchModel을 응답 DTO로 매핑 성공")
+    void toResponse_fromSearchModel_success() {
+        UUID reviewId = UUID.randomUUID();
+        UUID bookId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
+        Instant now = Instant.now();
+
+        ReviewSearchModel model = new ReviewSearchModel(
+                reviewId, bookId, "클린 코드", "https://example.com/image.jpg",
+                userId, "테스터", "좋은 책입니다", 5, 10, 3, true, now, now
+        );
+
+        ReviewResponse response = reviewMapper.toResponse(model);
+
+        assertThat(response.id()).isEqualTo(reviewId);
+        assertThat(response.bookId()).isEqualTo(bookId);
+        assertThat(response.bookTitle()).isEqualTo("클린 코드");
+        assertThat(response.userId()).isEqualTo(userId);
+        assertThat(response.userNickname()).isEqualTo("테스터");
+        assertThat(response.content()).isEqualTo("좋은 책입니다");
+        assertThat(response.rating()).isEqualTo(5);
+        assertThat(response.likeCount()).isEqualTo(10);
+        assertThat(response.commentCount()).isEqualTo(3);
         assertThat(response.likedByMe()).isTrue();
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/repository/ReviewRepositoryTest.java
@@ -216,38 +216,7 @@ class ReviewRepositoryTest {
         }
     }
 
-    @Nested
-    @DisplayName("댓글 수 감소")
-    class DecreaseCommentCount {
-        @Test
-        @DisplayName("댓글 수 감소 성공")
-        void decreaseCommentCount_Decreases_ActualDBValue() {
-            // given
-            Review review = reviewRepository.saveAndFlush(new Review(book, user, "리뷰 내용", 5));
-            reviewRepository.increaseCommentCount(review.getId());
-            reviewRepository.increaseCommentCount(review.getId());
 
-            // when
-            reviewRepository.decreaseCommentCount(review.getId());
-
-            // then
-            entityManager.clear();
-            Review updatedReview = reviewRepository.findById(review.getId()).get();
-
-            assertThat(updatedReview.getCommentCount()).isEqualTo(1);
-        }
-
-        @Test
-        @DisplayName("댓글 수 0 이하로 감소하지 않음 성공")
-        void decreaseCommentCount_notBelowZero_success() {
-            Review review = reviewRepository.saveAndFlush(new Review(book, user, "content", 5));
-            reviewRepository.decreaseCommentCount(review.getId());
-            entityManager.clear();
-
-            Review found = reviewRepository.findById(review.getId()).get();
-            assertThat(found.getCommentCount()).isEqualTo(0);
-        }
-    }
 
     @Nested
     @DisplayName("리뷰 물리 삭제 시 연관 객체 CASCADE 삭제")

--- a/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/review/service/ReviewServiceTest.java
@@ -3,6 +3,7 @@ package com.codeit.team4.deokhugam.review.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -23,6 +24,7 @@ import com.codeit.team4.deokhugam.review.entity.Review;
 import com.codeit.team4.deokhugam.review.mapper.ReviewMapper;
 import com.codeit.team4.deokhugam.review.repository.ReviewLikeRepository;
 import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
+import com.codeit.team4.deokhugam.review.repository.ReviewStatisticsRepository;
 import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.service.UserService;
 import java.time.Instant;
@@ -45,6 +47,9 @@ class ReviewServiceTest {
 
     @Mock
     private ReviewRepository reviewRepository;
+
+    @Mock
+    private ReviewStatisticsRepository reviewStatisticsRepository;
 
     @Mock
     private ReviewLikeRepository reviewLikeRepository;
@@ -95,7 +100,7 @@ class ReviewServiceTest {
             given(user.getId()).willReturn(userId);
             given(reviewRepository.existsByBookIdAndUserIdAndDeletedAtIsNull(bookId, userId)).willReturn(false);
             given(reviewRepository.save(any(Review.class))).willAnswer(invocation -> invocation.getArgument(0));
-            given(reviewMapper.toResponse(any(Review.class), eq(false))).willReturn(expectedResponse);
+            given(reviewMapper.toResponse(any(Review.class))).willReturn(expectedResponse);
 
             ReviewResponse response = reviewService.createReview(request);
 
@@ -191,9 +196,10 @@ class ReviewServiceTest {
                     Instant.now()
             );
 
+            given(review.getId()).willReturn(reviewId);
             given(reviewRepository.findByIdAndDeletedAtIsNull(reviewId)).willReturn(Optional.of(review));
             given(reviewLikeRepository.existsByReviewIdAndUserId(reviewId, userId)).willReturn(true);
-            given(reviewMapper.toResponse(review, true)).willReturn(expectedResponse);
+            given(reviewMapper.toResponse(eq(review), eq(true), anyInt())).willReturn(expectedResponse);
 
             ReviewResponse response = reviewService.getReview(reviewId, userId);
 
@@ -276,13 +282,14 @@ class ReviewServiceTest {
                     Instant.now()
             );
 
+            given(review.getId()).willReturn(reviewId);
             given(reviewRepository.findByIdAndDeletedAtIsNull(reviewId)).willReturn(Optional.of(review));
             given(review.isOwner(userId)).willReturn(true);
             given(review.getRating()).willReturn(5);
             given(review.getBook()).willReturn(book);
             given(book.getId()).willReturn(bookId);
             given(reviewLikeRepository.existsByReviewIdAndUserId(reviewId, userId)).willReturn(true);
-            given(reviewMapper.toResponse(review, true)).willReturn(expectedResponse);
+            given(reviewMapper.toResponse(eq(review), eq(true), anyInt())).willReturn(expectedResponse);
 
             ReviewResponse response = reviewService.updateReview(reviewId, userId, request);
 


### PR DESCRIPTION
## 관련 이슈
- closes #268

## 작업 내용
- 리뷰 서비스에서 리뷰 집계 테이블을 조회하게 수정

## 변경 사항
- ReviewService에서 ReviewResponse 반환 시 ReviewStatistics 에서 commentCount 를 가져오게 수정

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.
