### PR TITLE
feat: 대시보드 배치 점수 산정 시 기간 내 지표만 집계하도록 변경

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PopularReviewAggregationQueryBuilder.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PopularReviewAggregationQueryBuilder.java
@@ -1,7 +1,8 @@
 package com.codeit.team4.deokhugam.dashboard.builder;
 
 import static com.codeit.team4.deokhugam.jooq.tables.Books.BOOKS;
-import static com.codeit.team4.deokhugam.jooq.tables.ReviewStatistics.REVIEW_STATISTICS;
+import static com.codeit.team4.deokhugam.jooq.tables.Comments.COMMENTS;
+import static com.codeit.team4.deokhugam.jooq.tables.ReviewLikes.REVIEW_LIKES;
 import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
 
 import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
@@ -14,7 +15,11 @@ import java.time.ZoneId;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import org.jooq.Condition;
+import org.jooq.Field;
+import java.util.UUID;
+import org.jooq.Record2;
 import org.jooq.SortField;
+import org.jooq.Table;
 import org.jooq.impl.DSL;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -34,14 +39,66 @@ public class PopularReviewAggregationQueryBuilder {
         );
     }
 
-    public List<SortField<?>> buildOrderBy() {
-        SortField<?> scoreDesc = REVIEWS.LIKE_COUNT.cast(BigDecimal.class)
+    public List<SortField<?>> buildOrderBy(
+            Field<Integer> periodLikeCount,
+            Field<Integer> periodCommentCount
+    ) {
+        SortField<?> scoreDesc = periodLikeCount.cast(BigDecimal.class)
                 .mul(PopularReview.LIKE_COUNT_WEIGHT)
-                .add(DSL.coalesce(REVIEW_STATISTICS.COMMENT_COUNT, 0).cast(BigDecimal.class)
-                        .mul(PopularReview.COMMENT_COUNT_WEIGHT)) // NULL값이 있는 경우 0으로 처리
+                .add(periodCommentCount.cast(BigDecimal.class)
+                        .mul(PopularReview.COMMENT_COUNT_WEIGHT))
                 .desc();
 
         return List.of(scoreDesc, REVIEWS.CREATED_AT.asc(), REVIEWS.ID.asc());
+    }
+
+    public Table<Record2<UUID, Integer>> buildPeriodLikeCountTable(
+            PeriodType period,
+            LocalDate snapshotDate
+    ) {
+        Condition condition = REVIEW_LIKES.CREATED_AT.isNotNull();
+        OffsetDateTime startDateTime = getStartDateTime(period, snapshotDate);
+        OffsetDateTime endDateTime = getEndDateTime(snapshotDate);
+
+        if (startDateTime != null) {
+            condition = condition.and(REVIEW_LIKES.CREATED_AT.greaterOrEqual(startDateTime));
+        }
+        condition = condition.and(REVIEW_LIKES.CREATED_AT.lessThan(endDateTime));
+
+        return DSL.select(
+                        REVIEW_LIKES.REVIEW_ID.as("review_id"),
+                        DSL.count().as("like_count")
+                )
+                .from(REVIEW_LIKES)
+                .where(condition)
+                .groupBy(REVIEW_LIKES.REVIEW_ID)
+                .asTable("period_likes");
+    }
+
+    public Table<Record2<UUID, Integer>> buildPeriodCommentCountTable(
+            PeriodType period,
+            LocalDate snapshotDate
+    ) {
+        Condition condition = DSL.and(
+                COMMENTS.DELETED_AT.isNull(),
+                COMMENTS.CREATED_AT.isNotNull()
+        );
+        OffsetDateTime startDateTime = getStartDateTime(period, snapshotDate);
+        OffsetDateTime endDateTime = getEndDateTime(snapshotDate);
+
+        if (startDateTime != null) {
+            condition = condition.and(COMMENTS.CREATED_AT.greaterOrEqual(startDateTime));
+        }
+        condition = condition.and(COMMENTS.CREATED_AT.lessThan(endDateTime));
+
+        return DSL.select(
+                        COMMENTS.REVIEW_ID.as("review_id"),
+                        DSL.count().as("comment_count")
+                )
+                .from(COMMENTS)
+                .where(condition)
+                .groupBy(COMMENTS.REVIEW_ID)
+                .asTable("period_comments");
     }
 
     private Condition startDateCondition(PeriodType period, LocalDate snapshotDate) {
@@ -53,10 +110,13 @@ public class PopularReviewAggregationQueryBuilder {
     }
 
     private Condition endDateCondition(LocalDate snapshotDate) {
-        OffsetDateTime endDateTime = snapshotDate.plusDays(1)
+        return REVIEWS.CREATED_AT.lessThan(getEndDateTime(snapshotDate));
+    }
+
+    private OffsetDateTime getEndDateTime(LocalDate snapshotDate) {
+        return snapshotDate.plusDays(1)
                 .atStartOfDay(ZoneId.of(zone))
                 .toOffsetDateTime();
-        return REVIEWS.CREATED_AT.lessThan(endDateTime);
     }
 
     private OffsetDateTime getStartDateTime(PeriodType period, LocalDate snapshotDate) {

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PowerUserAggregationQueryBuilder.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/builder/PowerUserAggregationQueryBuilder.java
@@ -1,6 +1,7 @@
 package com.codeit.team4.deokhugam.dashboard.builder;
 
-import static com.codeit.team4.deokhugam.jooq.tables.ReviewStatistics.REVIEW_STATISTICS;
+import static com.codeit.team4.deokhugam.jooq.tables.Comments.COMMENTS;
+import static com.codeit.team4.deokhugam.jooq.tables.ReviewLikes.REVIEW_LIKES;
 import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
 import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
 
@@ -15,7 +16,11 @@ import java.time.ZoneId;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import org.jooq.Condition;
+import org.jooq.Field;
+import java.util.UUID;
+import org.jooq.Record2;
 import org.jooq.SortField;
+import org.jooq.Table;
 import org.jooq.impl.DSL;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -34,16 +39,68 @@ public class PowerUserAggregationQueryBuilder {
         );
     }
 
-    public List<SortField<?>> buildOrderBy() {
+    public List<SortField<?>> buildOrderBy(
+            Field<Integer> periodLikeCount,
+            Field<Integer> periodCommentCount
+    ) {
         SortField<?> scoreDesc = DSL.sum(
-                REVIEWS.LIKE_COUNT.cast(BigDecimal.class).mul(PopularReview.LIKE_COUNT_WEIGHT)
-                        .add(REVIEW_STATISTICS.COMMENT_COUNT.cast(BigDecimal.class).mul(PopularReview.COMMENT_COUNT_WEIGHT))
+                periodLikeCount.cast(BigDecimal.class).mul(PopularReview.LIKE_COUNT_WEIGHT)
+                        .add(periodCommentCount.cast(BigDecimal.class).mul(PopularReview.COMMENT_COUNT_WEIGHT))
         ).cast(BigDecimal.class).mul(PowerUser.REVIEW_SCORE_SUM_WEIGHT)
-                .add(DSL.sum(REVIEWS.LIKE_COUNT).cast(BigDecimal.class).mul(PowerUser.LIKE_COUNT_WEIGHT))
-                .add(DSL.sum(REVIEW_STATISTICS.COMMENT_COUNT).cast(BigDecimal.class).mul(PowerUser.COMMENT_COUNT_WEIGHT))
+                .add(DSL.sum(periodLikeCount).cast(BigDecimal.class).mul(PowerUser.LIKE_COUNT_WEIGHT))
+                .add(DSL.sum(periodCommentCount).cast(BigDecimal.class).mul(PowerUser.COMMENT_COUNT_WEIGHT))
                 .desc();
 
         return List.of(scoreDesc, USERS.CREATED_AT.asc(), REVIEWS.USER_ID.asc());
+    }
+
+    public Table<Record2<UUID, Integer>> buildPeriodLikeCountTable(
+            PeriodType period,
+            LocalDate snapshotDate
+    ) {
+        Condition condition = REVIEW_LIKES.CREATED_AT.isNotNull();
+        OffsetDateTime startDateTime = getStartDateTime(period, snapshotDate);
+        OffsetDateTime endDateTime = getEndDateTime(snapshotDate);
+
+        if (startDateTime != null) {
+            condition = condition.and(REVIEW_LIKES.CREATED_AT.greaterOrEqual(startDateTime));
+        }
+        condition = condition.and(REVIEW_LIKES.CREATED_AT.lessThan(endDateTime));
+
+        return DSL.select(
+                        REVIEW_LIKES.REVIEW_ID.as("review_id"),
+                        DSL.count().as("like_count")
+                )
+                .from(REVIEW_LIKES)
+                .where(condition)
+                .groupBy(REVIEW_LIKES.REVIEW_ID)
+                .asTable("period_likes");
+    }
+
+    public Table<Record2<UUID, Integer>> buildPeriodCommentCountTable(
+            PeriodType period,
+            LocalDate snapshotDate
+    ) {
+        Condition condition = DSL.and(
+                COMMENTS.DELETED_AT.isNull(),
+                COMMENTS.CREATED_AT.isNotNull()
+        );
+        OffsetDateTime startDateTime = getStartDateTime(period, snapshotDate);
+        OffsetDateTime endDateTime = getEndDateTime(snapshotDate);
+
+        if (startDateTime != null) {
+            condition = condition.and(COMMENTS.CREATED_AT.greaterOrEqual(startDateTime));
+        }
+        condition = condition.and(COMMENTS.CREATED_AT.lessThan(endDateTime));
+
+        return DSL.select(
+                        COMMENTS.REVIEW_ID.as("review_id"),
+                        DSL.count().as("comment_count")
+                )
+                .from(COMMENTS)
+                .where(condition)
+                .groupBy(COMMENTS.REVIEW_ID)
+                .asTable("period_comments");
     }
 
     private Condition startDateCondition(PeriodType period, LocalDate snapshotDate) {
@@ -55,10 +112,13 @@ public class PowerUserAggregationQueryBuilder {
     }
 
     private Condition endDateCondition(LocalDate snapshotDate) {
-        OffsetDateTime endDateTime = snapshotDate.plusDays(1)
+        return REVIEWS.CREATED_AT.lessThan(getEndDateTime(snapshotDate));
+    }
+
+    private OffsetDateTime getEndDateTime(LocalDate snapshotDate) {
+        return snapshotDate.plusDays(1)
                 .atStartOfDay(ZoneId.of(zone))
                 .toOffsetDateTime();
-        return REVIEWS.CREATED_AT.lessThan(endDateTime);
     }
 
     private OffsetDateTime getStartDateTime(PeriodType period, LocalDate snapshotDate) {

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/model/PopularReviewSearchModel.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/model/PopularReviewSearchModel.java
@@ -1,7 +1,6 @@
 package com.codeit.team4.deokhugam.dashboard.model;
 
 import static com.codeit.team4.deokhugam.jooq.tables.Books.BOOKS;
-import static com.codeit.team4.deokhugam.jooq.tables.ReviewStatistics.REVIEW_STATISTICS;
 import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
 import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
 
@@ -24,6 +23,12 @@ public record PopularReviewSearchModel(
         int commentCount
 ) {
 
+    public static final Field<Integer> PERIOD_LIKE_COUNT =
+            DSL.coalesce(DSL.field("period_likes.like_count", Integer.class), 0);
+
+    public static final Field<Integer> PERIOD_COMMENT_COUNT =
+            DSL.coalesce(DSL.field("period_comments.comment_count", Integer.class), 0);
+
     public static List<Field<?>> toSelectedFields() {
         return List.of(
                 REVIEWS.ID,
@@ -34,8 +39,8 @@ public record PopularReviewSearchModel(
                 USERS.NICKNAME,
                 REVIEWS.CONTENT,
                 REVIEWS.RATING,
-                REVIEWS.LIKE_COUNT,
-                DSL.coalesce(REVIEW_STATISTICS.COMMENT_COUNT, 0).as("comment_count")
+                PERIOD_LIKE_COUNT.as("period_like_count"),
+                PERIOD_COMMENT_COUNT.as("period_comment_count")
         );
     }
 
@@ -49,8 +54,8 @@ public record PopularReviewSearchModel(
                 rec.get(USERS.NICKNAME),
                 rec.get(REVIEWS.CONTENT),
                 rec.get(REVIEWS.RATING),
-                rec.get(REVIEWS.LIKE_COUNT),
-                rec.get("comment_count", Integer.class)
+                rec.get("period_like_count", Integer.class),
+                rec.get("period_comment_count", Integer.class)
         );
     }
 }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/model/PowerUserSearchModel.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/model/PowerUserSearchModel.java
@@ -1,6 +1,5 @@
 package com.codeit.team4.deokhugam.dashboard.model;
 
-import static com.codeit.team4.deokhugam.jooq.tables.ReviewStatistics.REVIEW_STATISTICS;
 import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
 import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
 
@@ -20,17 +19,22 @@ public record PowerUserSearchModel(
         int commentCount
 ) {
 
+    public static final Field<Integer> PERIOD_LIKE_COUNT =
+            DSL.coalesce(DSL.field("period_likes.like_count", Integer.class), 0);
+
+    public static final Field<Integer> PERIOD_COMMENT_COUNT =
+            DSL.coalesce(DSL.field("period_comments.comment_count", Integer.class), 0);
+
     private static final Field<BigDecimal> REVIEW_SCORE_SUM = DSL.sum(
-            REVIEWS.LIKE_COUNT.cast(BigDecimal.class).mul(PopularReview.LIKE_COUNT_WEIGHT)
-                    .add(DSL.coalesce(REVIEW_STATISTICS.COMMENT_COUNT, 0)
-                            .cast(BigDecimal.class).mul(PopularReview.COMMENT_COUNT_WEIGHT))
+            PERIOD_LIKE_COUNT.cast(BigDecimal.class).mul(PopularReview.LIKE_COUNT_WEIGHT)
+                    .add(PERIOD_COMMENT_COUNT.cast(BigDecimal.class).mul(PopularReview.COMMENT_COUNT_WEIGHT))
     ).as("review_score_sum");
 
     private static final Field<BigDecimal> LIKE_COUNT_SUM =
-            DSL.sum(REVIEWS.LIKE_COUNT).as("like_count_sum");
+            DSL.sum(PERIOD_LIKE_COUNT).as("like_count_sum");
 
     private static final Field<BigDecimal> COMMENT_COUNT_SUM =
-            DSL.sum(DSL.coalesce(REVIEW_STATISTICS.COMMENT_COUNT, 0)).as("comment_count_sum");
+            DSL.sum(PERIOD_COMMENT_COUNT).as("comment_count_sum");
 
     public static List<Field<?>> toSelectedFields() {
         return List.of(

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/service/PopularReviewAggregator.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/service/PopularReviewAggregator.java
@@ -1,7 +1,6 @@
 package com.codeit.team4.deokhugam.dashboard.service;
 
 import static com.codeit.team4.deokhugam.jooq.tables.Books.BOOKS;
-import static com.codeit.team4.deokhugam.jooq.tables.ReviewStatistics.REVIEW_STATISTICS;
 import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
 import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
 
@@ -10,8 +9,10 @@ import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
 import com.codeit.team4.deokhugam.dashboard.model.PopularReviewSearchModel;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
+import org.jooq.Table;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,13 +27,20 @@ public class PopularReviewAggregator {
     private final PopularReviewAggregationQueryBuilder aggregationQueryBuilder;
 
     public List<PopularReviewSearchModel> findTopReviews(PeriodType period, LocalDate snapshotDate) {
+        Table<?> periodLikes = aggregationQueryBuilder.buildPeriodLikeCountTable(period, snapshotDate);
+        Table<?> periodComments = aggregationQueryBuilder.buildPeriodCommentCountTable(period, snapshotDate);
+
         return dsl.select(PopularReviewSearchModel.toSelectedFields())
                 .from(REVIEWS)
                 .join(BOOKS).on(REVIEWS.BOOK_ID.eq(BOOKS.ID))
                 .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
-                .leftJoin(REVIEW_STATISTICS).on(REVIEW_STATISTICS.REVIEW_ID.eq(REVIEWS.ID))
+                .leftJoin(periodLikes).on(periodLikes.field("review_id", UUID.class).eq(REVIEWS.ID))
+                .leftJoin(periodComments).on(periodComments.field("review_id", UUID.class).eq(REVIEWS.ID))
                 .where(aggregationQueryBuilder.buildCondition(period, snapshotDate))
-                .orderBy(aggregationQueryBuilder.buildOrderBy())
+                .orderBy(aggregationQueryBuilder.buildOrderBy(
+                        PopularReviewSearchModel.PERIOD_LIKE_COUNT,
+                        PopularReviewSearchModel.PERIOD_COMMENT_COUNT
+                ))
                 .limit(POPULAR_REVIEW_LIMIT)
                 .fetch(PopularReviewSearchModel::fromRecord);
     }

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/service/PowerUserAggregator.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/service/PowerUserAggregator.java
@@ -1,6 +1,5 @@
 package com.codeit.team4.deokhugam.dashboard.service;
 
-import static com.codeit.team4.deokhugam.jooq.tables.ReviewStatistics.REVIEW_STATISTICS;
 import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
 import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
 
@@ -9,8 +8,10 @@ import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
 import com.codeit.team4.deokhugam.dashboard.model.PowerUserSearchModel;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
+import org.jooq.Table;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,13 +26,20 @@ public class PowerUserAggregator {
     private final PowerUserAggregationQueryBuilder aggregationQueryBuilder;
 
     public List<PowerUserSearchModel> findTopPowerUsers(PeriodType period, LocalDate snapshotDate) {
+        Table<?> periodLikes = aggregationQueryBuilder.buildPeriodLikeCountTable(period, snapshotDate);
+        Table<?> periodComments = aggregationQueryBuilder.buildPeriodCommentCountTable(period, snapshotDate);
+
         return dsl.select(PowerUserSearchModel.toSelectedFields())
                 .from(REVIEWS)
                 .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
-                .leftJoin(REVIEW_STATISTICS).on(REVIEW_STATISTICS.REVIEW_ID.eq(REVIEWS.ID))
+                .leftJoin(periodLikes).on(periodLikes.field("review_id", UUID.class).eq(REVIEWS.ID))
+                .leftJoin(periodComments).on(periodComments.field("review_id", UUID.class).eq(REVIEWS.ID))
                 .where(aggregationQueryBuilder.buildCondition(period, snapshotDate))
                 .groupBy(PowerUserSearchModel.toGroupByFields())
-                .orderBy(aggregationQueryBuilder.buildOrderBy())
+                .orderBy(aggregationQueryBuilder.buildOrderBy(
+                        PowerUserSearchModel.PERIOD_LIKE_COUNT,
+                        PowerUserSearchModel.PERIOD_COMMENT_COUNT
+                ))
                 .limit(POWER_USER_LIMIT)
                 .fetch(PowerUserSearchModel::fromRecord);
     }

--- a/src/main/resources/db/migration/V6__drop_reviews_comment_count.sql
+++ b/src/main/resources/db/migration/V6__drop_reviews_comment_count.sql
@@ -1,0 +1,1 @@
+ALTER TABLE reviews DROP COLUMN comment_count;

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/builder/PopularReviewAggregationQueryBuilderTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/builder/PopularReviewAggregationQueryBuilderTest.java
@@ -1,7 +1,6 @@
 package com.codeit.team4.deokhugam.dashboard.builder;
 
 import static com.codeit.team4.deokhugam.jooq.tables.Books.BOOKS;
-import static com.codeit.team4.deokhugam.jooq.tables.ReviewStatistics.REVIEW_STATISTICS;
 import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
 import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,6 +9,7 @@ import com.codeit.team4.deokhugam.book.entity.Book;
 import com.codeit.team4.deokhugam.book.repository.BookRepository;
 import com.codeit.team4.deokhugam.config.TestContainerConfig;
 import com.codeit.team4.deokhugam.dashboard.entity.PeriodType;
+import com.codeit.team4.deokhugam.dashboard.model.PopularReviewSearchModel;
 import com.codeit.team4.deokhugam.review.entity.Review;
 import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
 import com.codeit.team4.deokhugam.user.entity.User;
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.UUID;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
+import org.jooq.Table;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -170,7 +171,10 @@ class PopularReviewAggregationQueryBuilderTest {
         @Test
         @DisplayName("정렬 조건 3개 생성 성공")
         void buildOrderBy_hasThreeFields_success() {
-            assertThat(queryBuilder.buildOrderBy()).hasSize(3);
+            assertThat(queryBuilder.buildOrderBy(
+                    PopularReviewSearchModel.PERIOD_LIKE_COUNT,
+                        PopularReviewSearchModel.PERIOD_COMMENT_COUNT
+            )).hasSize(3);
         }
 
         @Test
@@ -184,23 +188,36 @@ class PopularReviewAggregationQueryBuilderTest {
 
             LocalDate today = LocalDate.now(ZoneId.of(zone));
             Condition condition = queryBuilder.buildCondition(PeriodType.ALL_TIME, today);
+            Table<?> periodLikes = queryBuilder.buildPeriodLikeCountTable(PeriodType.ALL_TIME, today);
+            Table<?> periodComments = queryBuilder.buildPeriodCommentCountTable(PeriodType.ALL_TIME, today);
 
             List<UUID> firstResult = dsl.select(REVIEWS.ID)
                     .from(REVIEWS)
                     .join(BOOKS).on(REVIEWS.BOOK_ID.eq(BOOKS.ID))
                     .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
-                    .leftJoin(REVIEW_STATISTICS).on(REVIEW_STATISTICS.REVIEW_ID.eq(REVIEWS.ID))
+                    .leftJoin(periodLikes).on(periodLikes.field("review_id", UUID.class).eq(REVIEWS.ID))
+                    .leftJoin(periodComments).on(periodComments.field("review_id", UUID.class).eq(REVIEWS.ID))
                     .where(condition)
-                    .orderBy(queryBuilder.buildOrderBy())
+                    .orderBy(queryBuilder.buildOrderBy(
+                            PopularReviewSearchModel.PERIOD_LIKE_COUNT,
+                            PopularReviewSearchModel.PERIOD_COMMENT_COUNT
+                    ))
                     .fetch(REVIEWS.ID);
+
+            periodLikes = queryBuilder.buildPeriodLikeCountTable(PeriodType.ALL_TIME, today);
+            periodComments = queryBuilder.buildPeriodCommentCountTable(PeriodType.ALL_TIME, today);
 
             List<UUID> secondResult = dsl.select(REVIEWS.ID)
                     .from(REVIEWS)
                     .join(BOOKS).on(REVIEWS.BOOK_ID.eq(BOOKS.ID))
                     .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
-                    .leftJoin(REVIEW_STATISTICS).on(REVIEW_STATISTICS.REVIEW_ID.eq(REVIEWS.ID))
+                    .leftJoin(periodLikes).on(periodLikes.field("review_id", UUID.class).eq(REVIEWS.ID))
+                    .leftJoin(periodComments).on(periodComments.field("review_id", UUID.class).eq(REVIEWS.ID))
                     .where(condition)
-                    .orderBy(queryBuilder.buildOrderBy())
+                    .orderBy(queryBuilder.buildOrderBy(
+                            PopularReviewSearchModel.PERIOD_LIKE_COUNT,
+                            PopularReviewSearchModel.PERIOD_COMMENT_COUNT
+                    ))
                     .fetch(REVIEWS.ID);
 
             assertThat(firstResult).hasSize(2);
@@ -220,14 +237,20 @@ class PopularReviewAggregationQueryBuilderTest {
 
             LocalDate today = LocalDate.now(ZoneId.of(zone));
             Condition condition = queryBuilder.buildCondition(PeriodType.ALL_TIME, today);
+            Table<?> periodLikes = queryBuilder.buildPeriodLikeCountTable(PeriodType.ALL_TIME, today);
+            Table<?> periodComments = queryBuilder.buildPeriodCommentCountTable(PeriodType.ALL_TIME, today);
 
             List<UUID> result = dsl.select(REVIEWS.ID)
                     .from(REVIEWS)
                     .join(BOOKS).on(REVIEWS.BOOK_ID.eq(BOOKS.ID))
                     .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
-                    .leftJoin(REVIEW_STATISTICS).on(REVIEW_STATISTICS.REVIEW_ID.eq(REVIEWS.ID))
+                    .leftJoin(periodLikes).on(periodLikes.field("review_id", UUID.class).eq(REVIEWS.ID))
+                    .leftJoin(periodComments).on(periodComments.field("review_id", UUID.class).eq(REVIEWS.ID))
                     .where(condition)
-                    .orderBy(queryBuilder.buildOrderBy())
+                    .orderBy(queryBuilder.buildOrderBy(
+                            PopularReviewSearchModel.PERIOD_LIKE_COUNT,
+                            PopularReviewSearchModel.PERIOD_COMMENT_COUNT
+                    ))
                     .fetch(REVIEWS.ID);
 
             assertThat(result).hasSize(2);

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/builder/PowerUserAggregationQueryBuilderTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/builder/PowerUserAggregationQueryBuilderTest.java
@@ -1,6 +1,5 @@
 package com.codeit.team4.deokhugam.dashboard.builder;
 
-import static com.codeit.team4.deokhugam.jooq.tables.ReviewStatistics.REVIEW_STATISTICS;
 import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
 import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,6 +19,7 @@ import java.util.List;
 import java.util.UUID;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
+import org.jooq.Table;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -155,7 +155,10 @@ class PowerUserAggregationQueryBuilderTest {
         @Test
         @DisplayName("정렬 조건 3개 생성 성공")
         void buildOrderBy_hasThreeFields_success() {
-            assertThat(queryBuilder.buildOrderBy()).hasSize(3);
+            assertThat(queryBuilder.buildOrderBy(
+                    PowerUserSearchModel.PERIOD_LIKE_COUNT,
+                        PowerUserSearchModel.PERIOD_COMMENT_COUNT
+            )).hasSize(3);
         }
 
         @Test
@@ -170,14 +173,20 @@ class PowerUserAggregationQueryBuilderTest {
 
             LocalDate today = LocalDate.now(ZoneId.of(zone));
             Condition condition = queryBuilder.buildCondition(PeriodType.ALL_TIME, today);
+            Table<?> periodLikes = queryBuilder.buildPeriodLikeCountTable(PeriodType.ALL_TIME, today);
+            Table<?> periodComments = queryBuilder.buildPeriodCommentCountTable(PeriodType.ALL_TIME, today);
 
             List<UUID> result = dsl.select(REVIEWS.USER_ID)
                     .from(REVIEWS)
                     .join(USERS).on(REVIEWS.USER_ID.eq(USERS.ID))
-                    .leftJoin(REVIEW_STATISTICS).on(REVIEW_STATISTICS.REVIEW_ID.eq(REVIEWS.ID))
+                    .leftJoin(periodLikes).on(periodLikes.field("review_id", UUID.class).eq(REVIEWS.ID))
+                    .leftJoin(periodComments).on(periodComments.field("review_id", UUID.class).eq(REVIEWS.ID))
                     .where(condition)
                     .groupBy(PowerUserSearchModel.toGroupByFields())
-                    .orderBy(queryBuilder.buildOrderBy())
+                    .orderBy(queryBuilder.buildOrderBy(
+                            PowerUserSearchModel.PERIOD_LIKE_COUNT,
+                            PowerUserSearchModel.PERIOD_COMMENT_COUNT
+                    ))
                     .fetch(REVIEWS.USER_ID);
 
             assertThat(result).hasSize(2);

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchServiceTest.java
@@ -99,6 +99,7 @@ class DashboardBatchServiceTest {
             dsl.insertInto(REVIEW_LIKES)
                     .set(REVIEW_LIKES.REVIEW_ID, reviewId)
                     .set(REVIEW_LIKES.USER_ID, likeUser.getId())
+                    .set(REVIEW_LIKES.CREATED_AT, todayTime())
                     .execute();
         }
     }
@@ -109,6 +110,8 @@ class DashboardBatchServiceTest {
                     .set(COMMENTS.REVIEW_ID, reviewId)
                     .set(COMMENTS.USER_ID, userId)
                     .set(COMMENTS.CONTENT, "댓글 " + i)
+                    .set(COMMENTS.CREATED_AT, todayTime())
+                    .set(COMMENTS.UPDATED_AT, todayTime())
                     .execute();
         }
     }
@@ -383,6 +386,56 @@ class DashboardBatchServiceTest {
 
             assertThat(allTimeReview.getLikeCount()).isEqualTo(13);
             assertThat(allTimeReview.getCommentCount()).isEqualTo(7);
+        }
+
+        @Test
+        @DisplayName("삭제된 댓글은 기간 내 댓글 수에 미포함 성공")
+        void updatePopularReviews_deletedCommentExcluded_success() {
+            Book book = createBook("삭제 댓글 테스트", "8888888888");
+            Review review = reviewRepository.saveAndFlush(new Review(book, user, "테스트 리뷰", 5));
+
+            // 오늘 댓글 3개 (정상 2개 + 삭제 1개)
+            insertCommentsAt(review.getId(), user.getId(), 2, todayTime());
+            dsl.insertInto(COMMENTS)
+                    .set(COMMENTS.REVIEW_ID, review.getId())
+                    .set(COMMENTS.USER_ID, user.getId())
+                    .set(COMMENTS.CONTENT, "삭제된 댓글")
+                    .set(COMMENTS.CREATED_AT, todayTime())
+                    .set(COMMENTS.UPDATED_AT, todayTime())
+                    .set(COMMENTS.DELETED_AT, todayTime())
+                    .execute();
+
+            LocalDate today = LocalDate.now(ZoneId.of(zone));
+            dashboardBatchService.updatePopularReviews(today);
+
+            PopularReview dailyReview = popularReviewRepository.findAll().stream()
+                    .filter(pr -> pr.getPeriod() == PeriodType.DAILY && pr.getSnapshotDate().equals(today))
+                    .findFirst().orElseThrow();
+
+            assertThat(dailyReview.getCommentCount()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("DAILY 기간 경계 시각 직전 데이터는 미포함 성공")
+        void updatePopularReviews_boundaryTime_success() {
+            Book book = createBook("경계 테스트 책", "7777777777");
+            Review review = reviewRepository.saveAndFlush(new Review(book, user, "테스트 리뷰", 5));
+
+            LocalDate today = LocalDate.now(ZoneId.of(zone));
+            OffsetDateTime startOfToday = today.atStartOfDay(ZoneId.of(zone)).toOffsetDateTime();
+
+            // 오늘 시작 직전 (어제 23:59:59) → DAILY에서 제외
+            insertReviewLikesAt(review.getId(), 5, startOfToday.minusSeconds(1));
+            // 오늘 시작 시각 → DAILY에 포함
+            insertReviewLikesAt(review.getId(), 2, startOfToday);
+
+            dashboardBatchService.updatePopularReviews(today);
+
+            PopularReview dailyReview = popularReviewRepository.findAll().stream()
+                    .filter(pr -> pr.getPeriod() == PeriodType.DAILY && pr.getSnapshotDate().equals(today))
+                    .findFirst().orElseThrow();
+
+            assertThat(dailyReview.getLikeCount()).isEqualTo(2);
         }
 
         @Test

--- a/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchServiceTest.java
@@ -16,8 +16,16 @@ import com.codeit.team4.deokhugam.review.entity.Review;
 import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
 import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.repository.UserRepository;
+import com.codeit.team4.deokhugam.review.entity.ReviewStatistics;
+import com.codeit.team4.deokhugam.review.repository.ReviewStatisticsRepository;
 import org.jooq.DSLContext;
+import static com.codeit.team4.deokhugam.jooq.tables.Comments.COMMENTS;
+import static com.codeit.team4.deokhugam.jooq.tables.ReviewLikes.REVIEW_LIKES;
 import static com.codeit.team4.deokhugam.jooq.tables.Reviews.REVIEWS;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.OffsetDateTime;
+import java.util.UUID;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
@@ -60,6 +68,9 @@ class DashboardBatchServiceTest {
     private BookRepository bookRepository;
 
     @Autowired
+    private ReviewStatisticsRepository reviewStatisticsRepository;
+
+    @Autowired
     private DSLContext dsl;
 
     @Value("${dashboard.batch.zone}")
@@ -70,6 +81,69 @@ class DashboardBatchServiceTest {
     @BeforeEach
     void setUp() {
         user = userRepository.saveAndFlush(new User("test@test.com", "테스터", "password123"));
+    }
+
+    private void saveReviewStatistics(java.util.UUID reviewId, int commentCount) {
+        ReviewStatistics stats = new ReviewStatistics(reviewId);
+        for (int i = 0; i < commentCount; i++) {
+            stats.onCommentCreated();
+        }
+        reviewStatisticsRepository.saveAndFlush(stats);
+    }
+
+    private void insertReviewLikes(UUID reviewId, UUID userId, int count) {
+        for (int i = 0; i < count; i++) {
+            User likeUser = userRepository.saveAndFlush(
+                    new User("like" + UUID.randomUUID() + "@test.com", "좋아요유저", "password123")
+            );
+            dsl.insertInto(REVIEW_LIKES)
+                    .set(REVIEW_LIKES.REVIEW_ID, reviewId)
+                    .set(REVIEW_LIKES.USER_ID, likeUser.getId())
+                    .execute();
+        }
+    }
+
+    private void insertComments(UUID reviewId, UUID userId, int count) {
+        for (int i = 0; i < count; i++) {
+            dsl.insertInto(COMMENTS)
+                    .set(COMMENTS.REVIEW_ID, reviewId)
+                    .set(COMMENTS.USER_ID, userId)
+                    .set(COMMENTS.CONTENT, "댓글 " + i)
+                    .execute();
+        }
+    }
+
+    private void insertReviewLikesAt(UUID reviewId, int count, OffsetDateTime createdAt) {
+        for (int i = 0; i < count; i++) {
+            User likeUser = userRepository.saveAndFlush(
+                    new User("like" + UUID.randomUUID() + "@test.com", "좋아요유저", "password123")
+            );
+            dsl.insertInto(REVIEW_LIKES)
+                    .set(REVIEW_LIKES.REVIEW_ID, reviewId)
+                    .set(REVIEW_LIKES.USER_ID, likeUser.getId())
+                    .set(REVIEW_LIKES.CREATED_AT, createdAt)
+                    .execute();
+        }
+    }
+
+    private void insertCommentsAt(UUID reviewId, UUID userId, int count, OffsetDateTime createdAt) {
+        for (int i = 0; i < count; i++) {
+            dsl.insertInto(COMMENTS)
+                    .set(COMMENTS.REVIEW_ID, reviewId)
+                    .set(COMMENTS.USER_ID, userId)
+                    .set(COMMENTS.CONTENT, "댓글 " + i)
+                    .set(COMMENTS.CREATED_AT, createdAt)
+                    .set(COMMENTS.UPDATED_AT, createdAt)
+                    .execute();
+        }
+    }
+
+    private OffsetDateTime todayTime() {
+        return LocalDate.now(ZoneId.of(zone)).atStartOfDay(ZoneId.of(zone)).toOffsetDateTime().plusHours(12);
+    }
+
+    private OffsetDateTime daysAgo(int days) {
+        return todayTime().minusDays(days);
     }
 
     private Book createBook(String title, String isbn) {
@@ -163,6 +237,45 @@ class DashboardBatchServiceTest {
                 assertThat(byPeriod).isNotEmpty();
             }
         }
+
+        @Test
+        @DisplayName("DAILY 기간 외 리뷰는 점수에 미포함 성공")
+        void updatePopularBooks_dailyPeriodFilter_success() {
+            Book book = createBook("기간 테스트 책", "9999999999");
+
+            // 오늘 리뷰 1개 (rating=5)
+            reviewRepository.saveAndFlush(new Review(book, user, "오늘 리뷰", 5));
+
+            // 어제 리뷰 1개 (rating=1) → DAILY에서는 제외되어야 함
+            User otherUser = userRepository.saveAndFlush(new User("other@test.com", "다른유저", "password123"));
+            Review oldReview = reviewRepository.saveAndFlush(new Review(book, otherUser, "어제 리뷰", 1));
+            dsl.update(REVIEWS).set(REVIEWS.CREATED_AT, daysAgo(1))
+                    .where(REVIEWS.ID.eq(oldReview.getId())).execute();
+
+            LocalDate today = LocalDate.now(ZoneId.of(zone));
+            dashboardBatchService.updatePopularBooks(today);
+
+            PopularBook dailyBook = popularBookRepository.findAll().stream()
+                    .filter(pb -> pb.getPeriod() == PeriodType.DAILY && pb.getSnapshotDate().equals(today))
+                    .findFirst().orElseThrow();
+
+            // DAILY: 오늘 리뷰 1개만 포함 → reviewCount=1, rating=5.00
+            assertThat(dailyBook.getReviewCount()).isEqualTo(1);
+            assertThat(dailyBook.getRating()).isEqualByComparingTo(new BigDecimal("5.00"));
+
+            // 점수 = 1 * 0.4 + 5.00 * 0.6 = 3.4000
+            BigDecimal expectedScore = new BigDecimal("1").multiply(PopularBook.REVIEW_COUNT_WEIGHT)
+                    .add(new BigDecimal("5.00").multiply(PopularBook.AVG_RATING_WEIGHT))
+                    .setScale(4, RoundingMode.HALF_UP);
+            assertThat(dailyBook.getScore()).isEqualByComparingTo(expectedScore);
+
+            // ALL_TIME: 전체 리뷰 2개 포함
+            PopularBook allTimeBook = popularBookRepository.findAll().stream()
+                    .filter(pb -> pb.getPeriod() == PeriodType.ALL_TIME && pb.getSnapshotDate().equals(today))
+                    .findFirst().orElseThrow();
+
+            assertThat(allTimeBook.getReviewCount()).isEqualTo(2);
+        }
     }
 
     @Nested
@@ -213,10 +326,10 @@ class DashboardBatchServiceTest {
 
             // review1: like=10, comment=5 → score = 10*0.3 + 5*0.7 = 6.5
             // review2: like=2, comment=1 → score = 2*0.3 + 1*0.7 = 1.3
-            dsl.update(REVIEWS).set(REVIEWS.LIKE_COUNT, 10).set(REVIEWS.COMMENT_COUNT, 5)
-                    .where(REVIEWS.ID.eq(review1.getId())).execute();
-            dsl.update(REVIEWS).set(REVIEWS.LIKE_COUNT, 2).set(REVIEWS.COMMENT_COUNT, 1)
-                    .where(REVIEWS.ID.eq(review2.getId())).execute();
+            insertReviewLikes(review1.getId(), user.getId(), 10);
+            insertComments(review1.getId(), user.getId(), 5);
+            insertReviewLikes(review2.getId(), user.getId(), 2);
+            insertComments(review2.getId(), user.getId(), 1);
 
             LocalDate today = LocalDate.now(ZoneId.of(zone));
             dashboardBatchService.updatePopularReviews(today);
@@ -230,6 +343,46 @@ class DashboardBatchServiceTest {
             assertThat(dailyReviews.get(0).getRank()).isEqualTo(1);
             assertThat(dailyReviews.get(1).getRank()).isEqualTo(2);
             assertThat(dailyReviews.get(0).getScore()).isGreaterThan(dailyReviews.get(1).getScore());
+        }
+
+        @Test
+        @DisplayName("DAILY 기간 외 좋아요/댓글은 count와 점수에 미포함 성공")
+        void updatePopularReviews_dailyPeriodFilter_success() {
+            Book book = createBook("기간 테스트 책", "9999999999");
+            Review review = reviewRepository.saveAndFlush(new Review(book, user, "테스트 리뷰", 5));
+
+            // 오늘 좋아요 3개, 오늘 댓글 2개
+            insertReviewLikesAt(review.getId(), 3, todayTime());
+            insertCommentsAt(review.getId(), user.getId(), 2, todayTime());
+
+            // 어제 좋아요 10개, 어제 댓글 5개 → DAILY에서 제외
+            insertReviewLikesAt(review.getId(), 10, daysAgo(1));
+            insertCommentsAt(review.getId(), user.getId(), 5, daysAgo(1));
+
+            LocalDate today = LocalDate.now(ZoneId.of(zone));
+            dashboardBatchService.updatePopularReviews(today);
+
+            PopularReview dailyReview = popularReviewRepository.findAll().stream()
+                    .filter(pr -> pr.getPeriod() == PeriodType.DAILY && pr.getSnapshotDate().equals(today))
+                    .findFirst().orElseThrow();
+
+            // DAILY: 오늘 좋아요 3개, 오늘 댓글 2개만 포함
+            assertThat(dailyReview.getLikeCount()).isEqualTo(3);
+            assertThat(dailyReview.getCommentCount()).isEqualTo(2);
+
+            // 점수 = 3 * 0.3 + 2 * 0.7 = 2.3000
+            BigDecimal expectedScore = new BigDecimal("3").multiply(PopularReview.LIKE_COUNT_WEIGHT)
+                    .add(new BigDecimal("2").multiply(PopularReview.COMMENT_COUNT_WEIGHT))
+                    .setScale(4, RoundingMode.HALF_UP);
+            assertThat(dailyReview.getScore()).isEqualByComparingTo(expectedScore);
+
+            // ALL_TIME: 전체 좋아요 13개, 전체 댓글 7개 포함
+            PopularReview allTimeReview = popularReviewRepository.findAll().stream()
+                    .filter(pr -> pr.getPeriod() == PeriodType.ALL_TIME && pr.getSnapshotDate().equals(today))
+                    .findFirst().orElseThrow();
+
+            assertThat(allTimeReview.getLikeCount()).isEqualTo(13);
+            assertThat(allTimeReview.getCommentCount()).isEqualTo(7);
         }
 
         @Test
@@ -308,13 +461,12 @@ class DashboardBatchServiceTest {
             Review review3 = reviewRepository.saveAndFlush(new Review(book3, otherUser, "괜찮아요", 3));
 
             // user 리뷰: like=10, comment=5 각각 → 활동 점수 높음
-            dsl.update(REVIEWS).set(REVIEWS.LIKE_COUNT, 10).set(REVIEWS.COMMENT_COUNT, 5)
-                    .where(REVIEWS.ID.eq(review1.getId())).execute();
-            dsl.update(REVIEWS).set(REVIEWS.LIKE_COUNT, 8).set(REVIEWS.COMMENT_COUNT, 4)
-                    .where(REVIEWS.ID.eq(review2.getId())).execute();
+            insertReviewLikes(review1.getId(), user.getId(), 10);
+            insertComments(review1.getId(), user.getId(), 5);
+            insertReviewLikes(review2.getId(), user.getId(), 8);
+            insertComments(review2.getId(), user.getId(), 4);
             // otherUser 리뷰: like=1, comment=0 → 활동 점수 낮음
-            dsl.update(REVIEWS).set(REVIEWS.LIKE_COUNT, 1).set(REVIEWS.COMMENT_COUNT, 0)
-                    .where(REVIEWS.ID.eq(review3.getId())).execute();
+            insertReviewLikes(review3.getId(), otherUser.getId(), 1);
 
             LocalDate today = LocalDate.now(ZoneId.of(zone));
             dashboardBatchService.updatePowerUsers(today);
@@ -328,6 +480,40 @@ class DashboardBatchServiceTest {
             assertThat(dailyUsers.get(0).getRank()).isEqualTo(1);
             assertThat(dailyUsers.get(1).getRank()).isEqualTo(2);
             assertThat(dailyUsers.get(0).getScore()).isGreaterThan(dailyUsers.get(1).getScore());
+        }
+
+        @Test
+        @DisplayName("DAILY 기간 외 좋아요/댓글은 count와 점수에 미포함 성공")
+        void updatePowerUsers_dailyPeriodFilter_success() {
+            Book book = createBook("기간 테스트 책", "9999999999");
+            Review review = reviewRepository.saveAndFlush(new Review(book, user, "테스트 리뷰", 5));
+
+            // 오늘 좋아요 4개, 오늘 댓글 3개
+            insertReviewLikesAt(review.getId(), 4, todayTime());
+            insertCommentsAt(review.getId(), user.getId(), 3, todayTime());
+
+            // 어제 좋아요 20개, 어제 댓글 10개 → DAILY에서 제외
+            insertReviewLikesAt(review.getId(), 20, daysAgo(1));
+            insertCommentsAt(review.getId(), user.getId(), 10, daysAgo(1));
+
+            LocalDate today = LocalDate.now(ZoneId.of(zone));
+            dashboardBatchService.updatePowerUsers(today);
+
+            PowerUser dailyUser = powerUserRepository.findAll().stream()
+                    .filter(pu -> pu.getPeriod() == PeriodType.DAILY && pu.getSnapshotDate().equals(today))
+                    .findFirst().orElseThrow();
+
+            // DAILY: 오늘 좋아요 4개, 오늘 댓글 3개만 포함
+            assertThat(dailyUser.getLikeCount()).isEqualTo(4);
+            assertThat(dailyUser.getCommentCount()).isEqualTo(3);
+
+            // ALL_TIME: 전체 좋아요 24개, 전체 댓글 13개 포함
+            PowerUser allTimeUser = powerUserRepository.findAll().stream()
+                    .filter(pu -> pu.getPeriod() == PeriodType.ALL_TIME && pu.getSnapshotDate().equals(today))
+                    .findFirst().orElseThrow();
+
+            assertThat(allTimeUser.getLikeCount()).isEqualTo(24);
+            assertThat(allTimeUser.getCommentCount()).isEqualTo(13);
         }
 
         @Test


### PR DESCRIPTION
## 관련 이슈
- closes #267

## 작업 내용
- 기존 대시보드 점수 산정에 기간 정보가 포함되지 않는 문제를 수정하였습니다.

## 변경 사항                                                                                                                                                                                                                             
  - PopularReviewAggregationQueryBuilder.java — 기간별 review_likes, comments 서브쿼리 빌드 메서드 추가                                                                                                                                                                                                                                                                                                                        
  - PopularReviewSearchModel.java — REVIEW_STATISTICS 대신 period_likes/period_comments 서브쿼리 필드 사용                                                                                                                                                                                                                                                                                                                        
  - PopularReviewAggregator.java — REVIEW_STATISTICS LEFT JOIN 제거, 서브쿼리 LEFT JOIN으로 교체                                                                                                                                                                                
                                                                                                                                                                                                                                         
## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 기간별(일일/전체) 인기 리뷰 순위 계산 정확성 개선
  * 기간별 파워 유저 순위 계산 정확성 개선
  * 일일 기간 필터링 로직 강화로 어제의 좋아요와 댓글이 오늘의 순위에 포함되지 않도록 수정

* **기타**
  * 데이터베이스 스키마 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->