### PR TITLE
fix: CloudWatch metric 에서 0.95 지표만 내보내게 변경

### DIFF
--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -23,7 +23,7 @@ management:
   metrics:
     distribution:
       percentiles:
-        http.server.requests: 0.5, 0.95, 0.99
+        http.server.requests: 0.95
 
 logging:
   level:


### PR DESCRIPTION
## 관련 이슈
- closes #274

## 작업 내용
- CloudWatch metric 에서 0.95 지표만 내보내게 변경
- 
- 

## 변경 사항
- application.yaml 변경

## 테스트 내용
- [ ] 테스트 코드 작성
- [ ] 로컬 테스트 완료
- [ ] API 테스트 완료
- [ ] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.
