### PR TITLE
fix: CommentQueryService 의 totalElements 삭제

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentQueryService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/comment/service/CommentQueryService.java
@@ -1,7 +1,6 @@
 package com.codeit.team4.deokhugam.comment.service;
 
 import static com.codeit.team4.deokhugam.jooq.tables.Comments.COMMENTS;
-import static com.codeit.team4.deokhugam.jooq.tables.ReviewStatistics.REVIEW_STATISTICS;
 import static com.codeit.team4.deokhugam.jooq.tables.Users.USERS;
 
 import com.codeit.team4.deokhugam.comment.dto.CommentResponse;
@@ -16,7 +15,6 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -92,16 +90,13 @@ public class CommentQueryService {
             nextAfter = last.createdAt();
         }
 
-        long totalElements = fetchReviewCommentCount(param.reviewId());
-
         List<CommentResponse> responses = content.stream()
                 .map(commentMapper::toResponse)
                 .toList();
 
         log.info("댓글 목록 조회 완료: reviewId={}, size={}", param.reviewId(), responses.size());
 
-        return new PageResponse<>(responses, nextCursor, nextAfter, param.limit(), totalElements,
-                hasNext);
+        return new PageResponse<>(responses, nextCursor, nextAfter, param.limit(), null, hasNext);
     }
 
     // ===== private =====
@@ -135,14 +130,5 @@ public class CommentQueryService {
         return isAsc
                 ? DSL.row(COMMENTS.CREATED_AT, COMMENTS.ID).gt(afterOffset, cursorId)
                 : DSL.row(COMMENTS.CREATED_AT, COMMENTS.ID).lt(afterOffset, cursorId);
-    }
-
-    private long fetchReviewCommentCount(UUID reviewId) {
-        return Optional.ofNullable(
-                dsl.select(REVIEW_STATISTICS.COMMENT_COUNT)
-                        .from(REVIEW_STATISTICS)
-                        .where(REVIEW_STATISTICS.REVIEW_ID.eq(reviewId))
-                        .fetchOneInto(Long.class)
-        ).orElse(0L);
     }
 }

--- a/src/test/java/com/codeit/team4/deokhugam/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/controller/CommentControllerTest.java
@@ -504,7 +504,7 @@ class CommentControllerTest {
                 null,
                 null,
                 50,
-                1L,
+                null,
                 false
         );
 
@@ -522,7 +522,7 @@ class CommentControllerTest {
                 .andExpect(jsonPath("$.content[0].userNickname").value("테스트닉네임"))
                 .andExpect(jsonPath("$.content[0].content").value("좋은 리뷰입니다"))
                 .andExpect(jsonPath("$.hasNext").value(false))
-                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.totalElements").isEmpty())
                 .andExpect(jsonPath("$.size").value(50));
     }
 
@@ -544,7 +544,7 @@ class CommentControllerTest {
                 now.toString(),  // nextCursor
                 now,             // nextAfter
                 2,
-                5L,
+                null,
                 true
         );
 
@@ -562,7 +562,7 @@ class CommentControllerTest {
                 .andExpect(jsonPath("$.hasNext").value(true))
                 .andExpect(jsonPath("$.nextCursor").exists())
                 .andExpect(jsonPath("$.nextAfter").exists())
-                .andExpect(jsonPath("$.totalElements").value(5));
+                .andExpect(jsonPath("$.totalElements").isEmpty());
     }
 
     @Test

--- a/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentQueryServiceTest.java
+++ b/src/test/java/com/codeit/team4/deokhugam/comment/service/CommentQueryServiceTest.java
@@ -15,9 +15,7 @@ import com.codeit.team4.deokhugam.global.error.ErrorCode;
 import com.codeit.team4.deokhugam.global.response.PageResponse;
 import com.codeit.team4.deokhugam.global.response.SortDirection;
 import com.codeit.team4.deokhugam.review.entity.Review;
-import com.codeit.team4.deokhugam.review.entity.ReviewStatistics;
 import com.codeit.team4.deokhugam.review.repository.ReviewRepository;
-import com.codeit.team4.deokhugam.review.repository.ReviewStatisticsRepository;
 import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.repository.UserRepository;
 import java.time.Instant;
@@ -54,9 +52,6 @@ class CommentQueryServiceTest {
 
     @Autowired
     private BookRepository bookRepository;
-
-    @Autowired
-    private ReviewStatisticsRepository reviewStatisticsRepository;
 
     private User user;
     private Review review;
@@ -157,11 +152,6 @@ class CommentQueryServiceTest {
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 1"));
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 2"));
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 3"));
-            ReviewStatistics stats = new ReviewStatistics(review.getId());
-            stats.onCommentCreated();
-            stats.onCommentCreated();
-            stats.onCommentCreated();
-            reviewStatisticsRepository.saveAndFlush(stats);
 
             CommentSearchRequestParam param = new CommentSearchRequestParam(
                     review.getId(), SortDirection.DESC, null, null, 2
@@ -175,7 +165,7 @@ class CommentQueryServiceTest {
             assertThat(result.hasNext()).isTrue();
             assertThat(result.nextCursor()).isNotNull();
             assertThat(result.nextAfter()).isNotNull();
-            assertThat(result.totalElements()).isEqualTo(3L);
+            assertThat(result.totalElements()).isNull();
         }
 
         @Test
@@ -185,11 +175,6 @@ class CommentQueryServiceTest {
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 1"));
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 2"));
             commentRepository.saveAndFlush(new Comment(user, review, "댓글 3"));
-            ReviewStatistics stats = new ReviewStatistics(review.getId());
-            stats.onCommentCreated();
-            stats.onCommentCreated();
-            stats.onCommentCreated();
-            reviewStatisticsRepository.saveAndFlush(stats);
 
             CommentSearchRequestParam firstReq = new CommentSearchRequestParam(
                     review.getId(), SortDirection.DESC, null, null, 2
@@ -210,7 +195,7 @@ class CommentQueryServiceTest {
             assertThat(secondRes.content()).hasSize(1);
             assertThat(secondRes.content().get(0).content()).isEqualTo("댓글 1");
             assertThat(secondRes.hasNext()).isFalse();
-            assertThat(secondRes.totalElements()).isEqualTo(3L);
+            assertThat(secondRes.totalElements()).isNull();
         }
 
         @Test


### PR DESCRIPTION
## 관련 이슈
- closes #269

## 작업 내용
- CommentQueryService 의 totalElements 삭제

## 변경 사항
- 삭제로 필요없어진 테스트와 import 정리

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.
