### PR TITLE
fix: 대시보드 배치 기준 날짜 어제로 수정

### DIFF
--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/controller/DashboardAdminController.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/controller/DashboardAdminController.java
@@ -25,7 +25,7 @@ public class DashboardAdminController implements DashboardAdminApi {
 
     @PostMapping("/batch")
     public ResponseEntity<Void> runBatch() {
-        LocalDate snapshotDate = LocalDate.now(ZoneId.of(zone));
+        LocalDate snapshotDate = DashboardBatchService.defaultSnapshotDate(zone);
         log.info("수동 배치 실행 요청: snapshotDate={}", snapshotDate);
         dashboardBatchService.updatePopularBooks(snapshotDate);
         dashboardBatchService.updatePopularReviews(snapshotDate);

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/scheduler/DashboardScheduler.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/scheduler/DashboardScheduler.java
@@ -2,7 +2,6 @@ package com.codeit.team4.deokhugam.dashboard.scheduler;
 
 import com.codeit.team4.deokhugam.dashboard.service.DashboardBatchService;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,7 +23,7 @@ public class DashboardScheduler {
     //TODO: Lock 추가 후 개선 예정
     @Scheduled(cron = "${dashboard.batch.cron}", zone = "${dashboard.batch.zone}")
     public void runDashboardBatch() {
-        LocalDate snapshotDate = LocalDate.now(ZoneId.of(zone)).minusDays(1);
+        LocalDate snapshotDate = DashboardBatchService.defaultSnapshotDate(zone);
         log.info("대시보드 배치 스케줄러 시작: snapshotDate={}", snapshotDate);
 
         try {

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/scheduler/DashboardScheduler.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/scheduler/DashboardScheduler.java
@@ -24,7 +24,7 @@ public class DashboardScheduler {
     //TODO: Lock 추가 후 개선 예정
     @Scheduled(cron = "${dashboard.batch.cron}", zone = "${dashboard.batch.zone}")
     public void runDashboardBatch() {
-        LocalDate snapshotDate = LocalDate.now(ZoneId.of(zone));
+        LocalDate snapshotDate = LocalDate.now(ZoneId.of(zone)).minusDays(1);
         log.info("대시보드 배치 스케줄러 시작: snapshotDate={}", snapshotDate);
 
         try {

--- a/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchService.java
+++ b/src/main/java/com/codeit/team4/deokhugam/dashboard/service/DashboardBatchService.java
@@ -22,6 +22,7 @@ import com.codeit.team4.deokhugam.user.entity.User;
 import com.codeit.team4.deokhugam.user.service.UserService;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +61,10 @@ public class DashboardBatchService {
     private final BookService bookService;
 
     private final ApplicationEventPublisher eventPublisher;
+
+    public static LocalDate defaultSnapshotDate(String zone) {
+        return LocalDate.now(ZoneId.of(zone)).minusDays(1);
+    }
 
     @CacheEvict(value = POPULAR_BOOKS, allEntries = true)
     public void updatePopularBooks(LocalDate snapshotDate) {


### PR DESCRIPTION
## 관련 이슈
- closes #286

## 작업 내용
- 대시보드에 월간 일간 랭킹 등록이 누락되는 문제
- 확인해본 결과 집계를 새벽 3시에 돌려서 5/1 데이터가 없어서 생긴 누락 (월간은 각 달의 1일부터 계산)
- 기준 날짜를 배치 날짜 기준 어제로 수정

## 변경 사항
- 기준 날짜 어제로 수정

## 테스트 내용
- [x] 테스트 코드 작성
- [x] 로컬 테스트 완료
- [x] API 테스트 완료
- [x] 기타 테스트 완료

## 체크리스트
- [x] 코드 컨벤션을 지켰습니다.
- [x] 불필요한 코드를 제거했습니다.
- [x] 주석이 필요한 부분에 추가했습니다.
- [x] 관련 문서를 수정했습니다.
- [x] 리뷰어가 이해하기 쉽도록 작성했습니다.

## 리뷰 포인트
- 중점적으로 봐줬으면 하는 부분을 작성해주세요.

## 스크린샷 / 참고 자료
- 필요한 경우 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **버그 수정**
  * 대시보드 배치 작업의 스냅샷 날짜 계산 방식을 조정하여, 현재 날짜 대신 전날을 기준으로 인기 도서, 인기 리뷰, 파워 사용자 데이터를 업데이트하도록 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->